### PR TITLE
Add dependencies to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,11 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     # packages=find_packages(['']),cmd
-    requires=['panda3d', ]
-    )
+    install_requires=[
+        'panda3d',
+        'pillow',
+        'psd-tools',
+        'imageio',
+        'psutil'
+    ]
+)


### PR DESCRIPTION
Hi,

This pull request adds all the dependences that you have listed on your readme package in the `setup.py` file so that when you run `python setup.py install` or `python setup.py develop`, all the dependencies required will automatically be installed as well.

Note, I added `psutil` as a dependency, I did not see anywhere in your documentation that it was required but when I tried to run a few of the samples it told me I was missing `psutil`, samples work fine after installing it.