### PR TITLE
Import functions directly from math in curve.py to speed up code.

### DIFF
--- a/ursina/curve.py
+++ b/ursina/curve.py
@@ -1,24 +1,31 @@
 '''Translated from https://github.com/AndrewRayCode/easing-utils/blob/master/src/easing.js'''
 
-import math
+from math import cos, pi, sqrt, sin, asin, floor
+
 
 def linear(t):
     return t
 
+
 def in_sine(t):
-    return -1 * math.cos(t * (math.pi / 2)) + 1
+    return -1 * cos(t * (pi / 2)) + 1
+
 
 def out_sine(t):
-    return math.sin(t * (math.pi / 2))
+    return sin(t * (pi / 2))
+
 
 def in_out_sine(t):
-    return -.5 * (math.cos(math.pi * t) - 1)
+    return -.5 * (cos(pi * t) - 1)
+
 
 def in_quad(t):
     return t * t
 
+
 def out_quad(t):
     return t * (2 - t)
+
 
 def in_out_quad(t):
     if t < .5:
@@ -26,12 +33,15 @@ def in_out_quad(t):
     else:
         return - 1 + (4 - 2 * t) * t
 
+
 def in_cubic(t):
     return t * t * t
+
 
 def out_cubic(t):
     t1 = t - 1
     return t1 * t1 * t1 + 1
+
 
 def in_out_cubic(t):
     if t < .5:
@@ -39,12 +49,15 @@ def in_out_cubic(t):
     else:
         return (t - 1) * (2 * t - 2) * (2 * t - 2) + 1
 
+
 def in_quart(t):
     return t * t * t * t
+
 
 def out_quart(t):
     t1 = t - 1
     return 1 - t1 * t1 * t1 * t1
+
 
 def in_out_quart(t):
     t1 = t - 1
@@ -53,12 +66,15 @@ def in_out_quart(t):
     else:
         1 - 8 * t1 * t1 * t1 * t1
 
+
 def in_quint(t):
     return t * t * t * t * t
+
 
 def out_quint(t):
     t1 = t - 1
     return 1 + t1 * t1 * t1 * t1 * t1
+
 
 def in_out_quint(t):
     t1 = t - 1
@@ -67,117 +83,130 @@ def in_out_quint(t):
     else:
         return 1 + 16 * t1 * t1 * t1 * t1 * t1
 
+
 def in_expo(t):
     return pow(2, 10 * (t - 1))
 
+
 def out_expo(t):
-    return (-pow(2, -10 * t) + 1)
+    return -pow(2, -10 * t) + 1
+
 
 def in_out_expo(t):
     scaledTime = t * 2
     scaledTime1 = scaledTime - 1
 
     if scaledTime < 1:
-        return .5 * pow(2, 10 * (scaledTime1))
+        return .5 * pow(2, 10 * scaledTime1)
 
     return .5 * (-pow(2, -10 * scaledTime1) + 2)
 
+
 def in_circ(t):
     scaledTime = t / 1
-    return -1 * (math.sqrt(1 - scaledTime * t) - 1)
+    return -1 * (sqrt(1 - scaledTime * t) - 1)
+
 
 def out_circ(t):
     t1 = t - 1
-    return math.sqrt(1 - t1 * t1)
+    return sqrt(1 - t1 * t1)
+
 
 def in_out_circ(t):
     scaledTime = t * 2
     scaledTime1 = scaledTime - 2
 
     if scaledTime < 1:
-        return -.5 * (math.sqrt(1 - scaledTime * scaledTime) - 1)
+        return -.5 * (sqrt(1 - scaledTime * scaledTime) - 1)
 
-    return .5 * (math.sqrt(1 - scaledTime1 * scaledTime1) + 1)
+    return .5 * (sqrt(1 - scaledTime1 * scaledTime1) + 1)
+
 
 def in_back(t, magnitude=1.70158):
     return t * t * ((magnitude + 1) * t - magnitude)
 
+
 def out_back(t, magnitude=1.70158):
     scaledTime = (t / 1) - 1
     return (
-        scaledTime * scaledTime * ((magnitude + 1) * scaledTime + magnitude)
-    ) + 1
+                   scaledTime * scaledTime * ((magnitude + 1) * scaledTime + magnitude)
+           ) + 1
+
 
 def in_out_back(t, magnitude=1.70158):
     scaledTime = t * 2
     scaledTime2 = scaledTime - 2
     s = magnitude * 1.525
 
-    if(scaledTime < 1):
+    if scaledTime < 1:
         return .5 * scaledTime * scaledTime * (
-            ((s + 1) * scaledTime) - s
+                ((s + 1) * scaledTime) - s
         )
     return .5 * (
-        scaledTime2 * scaledTime2 * ((s + 1) * scaledTime2 + s) + 2
+            scaledTime2 * scaledTime2 * ((s + 1) * scaledTime2 + s) + 2
     )
 
+
 def in_elastic(t, magnitude=.7):
-    if(t == 0 or t == 1):
+    if t == 0 or t == 1:
         return t
     scaledTime = t / 1
     scaledTime1 = scaledTime - 1
     p = 1 - magnitude
-    s = p / (2 * math.pi) * math.asin(1)
+    s = p / (2 * pi) * asin(1)
 
     return -(
-        pow(2, 10 * scaledTime1) *
-        math.sin((scaledTime1 - s) * (2 * math.pi) / p)
+            pow(2, 10 * scaledTime1) *
+            sin((scaledTime1 - s) * (2 * pi) / p)
     )
+
 
 def out_elastic(t, magnitude=.7):
     p = 1 - magnitude
     scaledTime = t * 2
 
-    if(t == 0 or t == 1):
+    if t == 0 or t == 1:
         return t
 
-    s = p / (2 * math.pi) * math.asin(1)
+    s = p / (2 * pi) * asin(1)
     return (
-        pow(2, -10 * scaledTime) *
-        math.sin((scaledTime - s) * (2 * math.pi) / p)
-    ) + 1
+                   pow(2, -10 * scaledTime) *
+                   sin((scaledTime - s) * (2 * pi) / p)
+           ) + 1
+
 
 def in_out_elastic(t, magnitude=0.65):
     p = 1 - magnitude
-    if(t == 0 or t == 1):
+    if t == 0 or t == 1:
         return t
 
     scaledTime = t * 2
     scaledTime1 = scaledTime - 1
-    s = p / (2 * math.pi) * math.asin(1)
+    s = p / (2 * pi) * asin(1)
 
-    if(scaledTime < 1):
+    if scaledTime < 1:
         return -.5 * (
-            pow(2, 10 * scaledTime1) *
-            math.sin((scaledTime1 - s) * (2 * math.pi) / p)
+                pow(2, 10 * scaledTime1) *
+                sin((scaledTime1 - s) * (2 * pi) / p)
         )
 
     return (
-        pow(2, -10 * scaledTime1) *
-        math.sin((scaledTime1 - s) * (2 * math.pi) / p) * .5
-    ) + 1
+                   pow(2, -10 * scaledTime1) *
+                   sin((scaledTime1 - s) * (2 * pi) / p) * .5
+           ) + 1
+
 
 def out_bounce(t):
     scaledTime = t / 1
 
-    if scaledTime < (1 / 2.75):
+    if scaledTime < 1 / 2.75:
         return 7.5625 * scaledTime * scaledTime
 
-    elif scaledTime < (2 / 2.75):
+    elif scaledTime < 2 / 2.75:
         scaledTime2 = scaledTime - (1.5 / 2.75)
         return (7.5625 * scaledTime2 * scaledTime2) + .75
 
-    elif scaledTime < (2.5 / 2.75):
+    elif scaledTime < 2.5 / 2.75:
         scaledTime2 = scaledTime - (2.25 / 2.75)
         return (7.5625 * scaledTime2 * scaledTime2) + 0.9375
 
@@ -185,15 +214,16 @@ def out_bounce(t):
         scaledTime2 = scaledTime - (2.625 / 2.75)
         return (7.5625 * scaledTime2 * scaledTime2) + 0.984375
 
+
 def in_bounce(t):
     return 1 - out_bounce(1 - t)
 
+
 def in_out_bounce(t):
-    if(t < .5):
+    if t < .5:
         return in_bounce(t * 2) * .5
 
     return (out_bounce((t * 2) - 1) * .5) + .5
-
 
 
 # generate boomeranged versions of all the functions
@@ -213,7 +243,7 @@ for e in dir(sys.modules[__name__]):
 
 
 # bezier code is translated  from WebKit implementation
-class CubicBezier():
+class CubicBezier:
     __slots__ = ['a', 'b', 'c', 'd', 'cx', 'bx', 'ax', 'cy', 'by', 'ay']
 
     def __init__(self, a, b, c, d):
@@ -225,18 +255,17 @@ class CubicBezier():
         # irst and last control points are implied to be (0,0) and (1.0, 1.0)
         self.cx = 3.0 * a
         self.bx = 3.0 * (c - a) - self.cx
-        self.ax = 1.0 - self.cx -self.bx
+        self.ax = 1.0 - self.cx - self.bx
 
         self.cy = 3.0 * b
         self.by = 3.0 * (d - b) - self.cy
         self.ay = 1.0 - self.cy - self.by
 
-
     def sample_curve_x(self, t):
         return ((self.ax * t + self.bx) * t + self.cx) * t
 
     def sample_curve_y(self, t):
-        return ((self.ay * t + self.by) * t + self.cy) * t;
+        return ((self.ay * t + self.by) * t + self.cy) * t
 
     def sample_curve_derivative_x(self, t):
         return (3.0 * self.ax * t + 2.0 * self.bx) * t + self.cx
@@ -276,7 +305,7 @@ class CubicBezier():
 
         while t0 < t1:
             x2 = self.sample_curve_x(t2)
-            if abs(x2-t) < epsilon:
+            if abs(x2 - t) < epsilon:
                 return t2
             if t > x2:
                 t0 = t2
@@ -292,19 +321,22 @@ class CubicBezier():
 if __name__ == '__main__':
     '''Draws a sheet with every curve and it's name'''
     from ursina import *
+
     app = Ursina()
     camera.orthographic = True
     camera.fov = 16
     camera.position = (9, 6)
-    window.color=color.black
+    window.color = color.black
 
     i = 0
     for e in dir(curve):
         try:
             item = getattr(curve, e)
             print(item.__name__, ':', item(.75))
-            curve_renderer = Entity(model=Mesh(vertices=[Vec3(i/31, item(i/31), 0) for i in range(32)], mode='line', thickness=2), color=color.light_gray)
-            row = math.floor(i/8)
+            curve_renderer = Entity(
+                model=Mesh(vertices=[Vec3(i / 31, item(i / 31), 0) for i in range(32)], mode='line', thickness=2),
+                color=color.light_gray)
+            row = floor(i / 8)
             curve_renderer.x = (i % 8) * 2.5
             curve_renderer.y = row * 1.75
             label = Text(parent=curve_renderer, text=item.__name__, scale=8, color=color.gray, y=-.1)
@@ -312,7 +344,7 @@ if __name__ == '__main__':
         except:
             pass
 
-    c = CubicBezier(0,.5,1,.5)
+    c = CubicBezier(0, .5, 1, .5)
     print('-----------', c.calculate(.23))
     # for x, c in enumerate([curve.CubicBezier(0,1,1,0), curve.CubicBezier(0,.5,1,.5), curve.CubicBezier(0,0,0,0), curve.CubicBezier(0,.7,1,.3)]):
     #     verts = [Vec3(i/20, c.calculate(i/20), 0) for i in range(20)]
@@ -321,7 +353,6 @@ if __name__ == '__main__':
     window.exit_button.visible = False
     window.fps_counter.enabled = False
     app.run()
-
     '''
     These are used by Entity when animating, like this:
 


### PR DESCRIPTION
Generally, using from math import fn1, fn2, ... is faster than math.fn1, which is important for tight loops. I also updated a few lines to better adhere to PEP8.

I've included a trivial example below:

```
python -mtimeit -s"import math" "math.sqrt(6.31)"
5000000 loops, best of 5: 93.4 nsec per loop

python -mtimeit -s"from math import sqrt" "sqrt(6.31)"
5000000 loops, best of 5: 68.7 nsec per loop
```