### PR TITLE
Add InputEvents enum

### DIFF
--- a/ursina/input_handler.py
+++ b/ursina/input_handler.py
@@ -52,6 +52,9 @@ class InputEvents(Enum):
     page_down_up = 'page down up'
     page_up = 'page up'
     page_up_up = 'page up up'
+    
+    def __hash__(self):
+        return hash(self.value)
 
     def __eq__(self, other):
         """ Overriden __eq__ to allow for both str and InputEvent comparisions """

--- a/ursina/input_handler.py
+++ b/ursina/input_handler.py
@@ -1,6 +1,6 @@
 import sys
 from collections import defaultdict
-
+from enum import Enum
 
 control = False
 left_control = False
@@ -18,10 +18,53 @@ held_keys = defaultdict(lambda: 0)
 rebinds = dict()
 
 
+class InputEvents(Enum):
+    """ Common mouse events """
+    left_mouse_down = 'left mouse down'
+    left_mouse_up = 'left mouse up'
+    middle_mouse_down = 'middle mouse down'
+    middle_mouse_up = 'middle mouse up'
+    right_mouse_down = 'right mouse down'
+    right_mouse_up = 'right mouse up'
+    scroll_up = 'scroll up'
+    scroll_down = 'scroll down'
+    arrow_left = 'arrow left'
+    arrow_left_up = 'arrow left up'
+    arrow_up = 'arrow up'
+    arrow_up_up = 'arrow up up'
+    arrow_down = 'arrow down'
+    arrow_down_up = 'arrow down up'
+    arrow_right = 'arrow right'
+    arrow_right_up = 'arrow right up'
+    left_control = 'left control'
+    right_control = 'right control'
+    left_shift = 'left shift'
+    right_shift = 'right shift'
+    left_alt = 'left alt'
+    right_alt = 'right alt'
+    left_control_up = 'left control up'
+    right_control_up = 'right control up'
+    left_shift_up = 'left shift up'
+    right_shift_up = 'right shift up'
+    left_alt_up = 'left alt up'
+    right_alt_up = 'right alt up'
+    page_down = 'page down'
+    page_down_up = 'page down up'
+    page_up = 'page up'
+    page_up_up = 'page up up'
+
+    def __eq__(self, other):
+        """ Overriden __eq__ to allow for both str and InputEvent comparisions """
+        if isinstance(other, InputEvents):
+            return self.value == other.value
+        return self.value == other
+
+
 def bind(original_key, alternative_key):
     rebinds[original_key] = alternative_key
     rebinds[original_key + ' hold'] = alternative_key + ' hold'
     rebinds[original_key + ' up'] = alternative_key + ' up'
+
 
 def unbind(key):
     if key in rebinds:
@@ -31,16 +74,17 @@ def unbind(key):
     else:
         rebinds[key] = 'none'
 
+
 def rebind(to_key, from_key):
     unbind(to_key)
     bind(to_key, from_key)
 
 
 def input(key):
-    if key == 'arrow up':
+    if key == InputEvents.arrow_up:
         held_keys[key] = 1
         return
-    elif key == 'arrow up up':
+    elif key == InputEvents.arrow_up_up:
         held_keys['arrow up'] = 0
         return
 
@@ -59,11 +103,14 @@ if __name__ == '__main__':
     space
     '''
     from ursina import *
+
     app = Ursina()
-    input_handler.bind('s', 'arrow down')   # 's'-key will now be registered as 'arrow down'-key
+    input_handler.bind('s', 'arrow down')  # 's'-key will now be registered as 'arrow down'-key
+
     # input_handler.rebind('a', 'f')
     def input(key):
         print(key)
+
 
     # Is there a gamepad connected?
     # from panda3d.core import InputDevice


### PR DESCRIPTION
Having the various keys available in an enum is helpful for two reasons - all the keys are in one place, and you don't need to memorize which string corresponds to a given key - just import the enum from InputEvents. This is also helpful if the values change in the future, since they can easily be rebound,