### PR TITLE
Remove == True check in camera.py

### DIFF
--- a/ursina/camera.py
+++ b/ursina/camera.py
@@ -86,7 +86,7 @@ class Camera(Entity):
     @orthographic.setter
     def orthographic(self, value):
         self._orthographic = value
-        if value == True:
+        if value:
             self.lens = self.orthographic_lens
             self.lens_node = self.orthographic_lens_node
             application.base.cam.node().set_lens(self.orthographic_lens)


### PR DESCRIPTION
Using == True to check for a value being true is incorrect, as classes may override the == comparator. I don't know if you need self._orthographic to strictly be a boolean - if so, you could use

```
    @orthographic.setter
    def orthographic(self, value):
        self._orthographic = value
        if value is True:
            self.lens = self.orthographic_lens
            self.lens_node = self.orthographic_lens_node
            application.base.cam.node().set_lens(self.orthographic_lens)
        elif value is False:
            self.lens = self.perspective_lens
            self.lens_node = self.perspective_lens_node
            application.base.cam.node().set_lens(self.perspective_lens)
        else:
              raise ValueError("Camera.orthographic must be set to a boolean value")
        self.fov = self.fov
```

The current change fixes a potential bug where you could set orthographic to some value such as two, for which `2 == True` is false, which would set the Camera to perspective mode, but `self.orthographic` below behaves as a True value:

```
        if not self.orthographic and hasattr(self, 'perspective_lens'):
            self.perspective_lens.set_fov(value)
            application.base.cam.node().set_lens(self.perspective_lens)

        elif self.orthographic and hasattr(self, 'orthographic_lens'):
            self.orthographic_lens.set_film_size(value * self.aspect_ratio, value)
            application.base.cam.node().set_lens(self.orthographic_lens)
```

