### PR TITLE
Fix import error false positive

### DIFF
--- a/ursina/texture_importer.py
+++ b/ursina/texture_importer.py
@@ -6,8 +6,8 @@ from ursina.texture import Texture
 has_psd_tools_installed = False
 try:
     from psd_tools import PSDImage
-    has_psd_tools_installed = true
-except Exception as e:
+    has_psd_tools_installed = True
+except (ModuleNotFoundError, ImportError) as e:
     print('psd-tools not installed')
 
 


### PR DESCRIPTION
Change "true" to "True". Change catch-all exception to those we really want.

Due to the syntax error and the catch-all exception, psd-tools could never be detected, even when it was properly installed.