### PR TITLE
begin testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 __pycache__
+.pytest_cache
 ursina.egg-info
 dist
 /build

--- a/test.py
+++ b/test.py
@@ -1,12 +1,29 @@
 """Test Ursina."""
 
+import logging
+import textwrap
+
+_log = logging.getLogger(__name__)
+
 
 def main():
+    """Run ursina unit tests using pytest.
+
+    Pytest is not a requirement, so in the event that it is not already
+    installed, instruct the user on running tests in an automated fashion
+    using Python's included unittest package.
+    """
     try:
         import pytest
     except ImportError:
-        err = lambda msg: print(f"Error: {msg}")
-        err("You need to install pytest! O:")
+        _log.error(textwrap.dedent(f"""\
+            Pytest is the preferred method of running unit tests. Please run
+            the following command, then re-run {__file__}.
+                python -m pip install pytest
+
+            Otherwise, run the following command from the repository root:
+                python -m unittest discover -s test
+        """))
     else:
         pytest.main()
 

--- a/test.py
+++ b/test.py
@@ -1,0 +1,15 @@
+"""Test Ursina."""
+
+
+def main():
+    try:
+        import pytest
+    except ImportError:
+        err = lambda msg: print(f"Error: {msg}")
+        err("You need to install pytest! O:")
+    else:
+        pytest.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,0 +1,31 @@
+"""Test common Ursina functionality."""
+
+import unittest
+from unittest.mock import patch
+
+import ursina
+
+
+class TestUrsina(unittest.TestCase):
+
+    @patch("direct.showbase.ShowBase.ShowBase.run")
+    def test_basic_ursina_window_creation(self, mock_showbase_run):
+        """Ensure instantiating an Ursina object creates a window.
+
+        Given an Ursina object
+        When the run() method is called on that object
+        Then a window is created
+        """
+
+        # Given
+        app = ursina.Ursina()
+
+        # When
+        app.run()
+
+        # Then
+        self.assertGreater(mock_showbase_run.call_count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -9,12 +9,17 @@ import ursina
 class TestUrsina(unittest.TestCase):
 
     @patch("direct.showbase.ShowBase.ShowBase.run")
-    def test_basic_ursina_window_creation(self, mock_showbase_run):
-        """Ensure instantiating an Ursina object creates a window.
+    def test_ursina_window_creation(self, mock_showbase_run):
+        """Test Ursina window creation.
+
+        Because we are unable to easily identify windows on the screen,
+        capturing the number of calls to the library method which creates
+        them is a good approximation. Unfortunately this means that we're
+        testing implementation instead of behaviour.
 
         Given an Ursina object
         When the run() method is called on that object
-        Then a window is created
+        Then ShowBase.run is called at least once.
         """
 
         # Given


### PR DESCRIPTION
This adds a developer dependency: Pytest. Everything else is already included with Python >= 3.3.

I'd very much prefer to work within the safe harbors of unit tests. Is this something you're comfortable with?