### PR TITLE
compress_models could not run blender on linux

### DIFF
--- a/ursina/mesh_importer.py
+++ b/ursina/mesh_importer.py
@@ -104,7 +104,7 @@ def compress_models(path=None, outpath=application.compressed_models_folder, nam
 
         out_file_path = outpath / (blend_file.stem + '.obj')
         print('converting .blend file to .obj:', blend_file, '-->', out_file_path, 'using:', blender)
-        subprocess.call(f'''{blender} {blend_file} --background --python {export_script_path} {out_file_path}''')
+        subprocess.run((blender, blend_file, '--background', '--python', export_script_path, out_file_path))
         exported.append(blend_file)
 
     return exported


### PR DESCRIPTION
The call to subprocess.call was not quite structured correctly.
Replaced subprocess.call with subprocess.run, as subprocess.run is the recommended way as of Python 3.5.