### PR TITLE
attempt to run in Jupyter notebook

### DIFF
--- a/ursina/main.py
+++ b/ursina/main.py
@@ -220,21 +220,6 @@ class Ursina(ShowBase):
         super().run()
 
 
-    def isJupyter():        # from https://stackoverflow.com/questions/15411967/how-can-i-check-if-code-is-executed-in-the-ipython-notebook/24937408
-        try:
-            shell = get_ipython().__class__.__name__
-            if shell == 'ZMQInteractiveShell':
-                return True   # Jupyter notebook or qtconsole
-            elif shell == 'TerminalInteractiveShell':
-                return False  # Terminal running IPython
-            else:
-                return False  # Other type (?)
-        except NameError:
-            return False      # Probably standard Python interprete
-
-
-
-
 if __name__ == '__main__':
     app = Ursina()
     app.run()

--- a/ursina/main.py
+++ b/ursina/main.py
@@ -2,7 +2,6 @@ import time
 from ursina.ursinastuff import *
 import __main__
 
-
 class Ursina(ShowBase):
 
     def __init__(self):
@@ -84,7 +83,7 @@ class Ursina(ShowBase):
         # try to load settings that need to be applied before entity creation
         application.load_settings()
 
-        if application.development_mode:
+        if application.development_mode and hasattr(__main__, '__file__'):
             from ursina import HotReloader
             application.hot_reloader = HotReloader(__main__.__file__)
 
@@ -198,6 +197,13 @@ class Ursina(ShowBase):
         if key == 'f9':
             window.display_mode = 'default'
 
+
+
+        if key == 'escape':
+            self.destroy()  # must firmly close app for Jupyter
+            import os
+            os._exit(0)
+
         # if key == 'escape':
         #     if not application.paused:
         #         application.pause()
@@ -212,6 +218,21 @@ class Ursina(ShowBase):
         application.load_settings()
 
         super().run()
+
+
+    def isJupyter():        # from https://stackoverflow.com/questions/15411967/how-can-i-check-if-code-is-executed-in-the-ipython-notebook/24937408
+        try:
+            shell = get_ipython().__class__.__name__
+            if shell == 'ZMQInteractiveShell':
+                return True   # Jupyter notebook or qtconsole
+            elif shell == 'TerminalInteractiveShell':
+                return False  # Terminal running IPython
+            else:
+                return False  # Other type (?)
+        except NameError:
+            return False      # Probably standard Python interprete
+
+
 
 
 if __name__ == '__main__':

--- a/ursina/prefabs/exit_button.py
+++ b/ursina/prefabs/exit_button.py
@@ -15,8 +15,12 @@ class ExitButton(Button):
             **kwargs)
 
 
-    def on_click(self):
-        application.quit()
+    def on_click(self):  # this does NOT work under Jupyter
+        # application.quit()
+        self.destroy()  # must firmly close app for Jupyter
+        import os
+        os._exit(0)  # may kill the iPython kernal, the user will be prompted to restart
+
 
 
     def input(self, key):

--- a/ursina/window.py
+++ b/ursina/window.py
@@ -107,29 +107,31 @@ class Window(WindowProperties):
         if not application.development_mode:
             return
 
-        import webbrowser
-        self.cog_menu = ButtonList({
-            # 'Build' : Func(print, ' '),
-            'Asset Store' : Func(webbrowser.open, "https://itch.io/tools/tag-ursina"),
-            # 'Open Scene Editor' : Func(print, ' '),
-            'Reload Textures [F6]' : application.hot_reloader.reload_textures,
-            'Reload Models [F7]' : application.hot_reloader.reload_models,
-            'Reload Code [F5]' : application.hot_reloader.reload_code,
-        },
-            width=.3,
-            x=.64,
-            enabled=False,
-            eternal=True
-        )
-        self.cog_menu.on_click = Func(setattr, self.cog_menu, 'enabled', False)
-        self.cog_menu.y = -.5 + self.cog_menu.scale_y
-        self.cog_menu.scale *= .75
-        self.cog_menu.text_entity.x += .025
-        self.cog_menu.highlight.color = color.azure
-        self.cog = Button(parent=self.editor_ui, eternal=True, model='circle', scale=.015, origin=(1,-1), position=self.bottom_right)
-        def _toggle_cog_menu():
-            self.cog_menu.enabled = not self.cog_menu.enabled
-        self.cog.on_click = _toggle_cog_menu
+        if not self.isJupyter():  # don't try a hot reload in Jupyter notebook
+
+            import webbrowser
+            self.cog_menu = ButtonList({
+                # 'Build' : Func(print, ' '),
+                'Asset Store' : Func(webbrowser.open, "https://itch.io/tools/tag-ursina"),
+                # 'Open Scene Editor' : Func(print, ' '),
+                'Reload Textures [F6]' : application.hot_reloader.reload_textures,
+                'Reload Models [F7]' : application.hot_reloader.reload_models,
+                'Reload Code [F5]' : application.hot_reloader.reload_code,
+            },
+                width=.3,
+                x=.64,
+                enabled=False,
+                eternal=True
+            )
+            self.cog_menu.on_click = Func(setattr, self.cog_menu, 'enabled', False)
+            self.cog_menu.y = -.5 + self.cog_menu.scale_y
+            self.cog_menu.scale *= .75
+            self.cog_menu.text_entity.x += .025
+            self.cog_menu.highlight.color = color.azure
+            self.cog = Button(parent=self.editor_ui, eternal=True, model='circle', scale=.015, origin=(1,-1), position=self.bottom_right)
+            def _toggle_cog_menu():
+                self.cog_menu.enabled = not self.cog_menu.enabled
+            self.cog.on_click = _toggle_cog_menu
 
 
     def update_aspect_ratio(self):
@@ -240,6 +242,23 @@ class Window(WindowProperties):
                 loadPrcFileData('', 'sync-video False')
                 print('set vsync to false')
             object.__setattr__(self, name, value)
+
+
+    def isJupyter(self):        # from https://stackoverflow.com/questions/15411967/how-can-i-check-if-code-is-executed-in-the-ipython-notebook/24937408
+        try:
+            shell = get_ipython().__class__.__name__
+            if shell == 'ZMQInteractiveShell':
+                return True   # Jupyter notebook or qtconsole
+            elif shell == 'TerminalInteractiveShell':
+                return False  # Terminal running IPython
+            else:
+                return False  # Other type (?)
+        except NameError:
+            return False      # Probably standard Python interprete
+
+
+
+
 
 
 sys.modules[__name__] = Window()


### PR DESCRIPTION
Hi Petter.  I did my best, but this PR does NOT work cleanly.  It probably doesn't do any harm, and maybe you will understand the problem better.

Hot reload doesn't work in a Jupyter notebook because there is no filepath.  So I added a method in **Windows.py** to determine whether we were in a notebook and avoid the hot_reload.  That seems fine.  There was also a reference to hot_reload in **Main.py** that was failing, I put in a more generic check there.

The remaining problem is that a game must be FIRMLY killed in a Jupyter notebook to be runnable again.  I added an exit to the 'escape' key in **Main.py**, which works perfectly.  But the same code does NOT work in **Exit_button.py**, and leaves iPython locked.  This takes more understanding of events in Python that I have.

If you accept this PR, then I believe the only difference Ursina users will see is that Escape ends the game.  But it would be nice to get the X to exit the game as expected.  Perhaps there is a different way to end a game cleanly?  