### PR TITLE
Add numpy as a required dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
+        'numpy',
         'panda3d',
         'pillow',
         'screeninfo',


### PR DESCRIPTION
Fixes #56 by introducing `numpy` as a required dependency.