### PR TITLE
Added loading shader from files.

### DIFF
--- a/ursina/shader.py
+++ b/ursina/shader.py
@@ -1,4 +1,6 @@
+from pathlib import Path
 from panda3d.core import Shader as Panda3dShader
+from ursina import application
 
 default_vertex_shader = '''
 #version 430
@@ -41,6 +43,24 @@ class Shader:
 
         for key, value in kwargs.items():
             setattr(self, key ,value)
+
+    @classmethod
+    def load(cls, language=Panda3dShader.SL_GLSL, vertex=None, fragment=None, geometry=None, **kwargs):
+        parts = {"vertex": vertex, "fragment": fragment, "geometry": geometry}
+        parts = {k: v for k, v in parts.items() if v}
+
+        folders = (  # folder search order
+            application.asset_folder,
+        )
+
+        for sh, name in parts.items():
+            for folder in folders:
+                for filename in folder.glob('**/' + name):
+                    with filename.open("rt") as f:
+                        parts[sh] = f.read()
+
+        parts.update(kwargs)
+        return cls(language, **parts)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added possibility to load shader from files. Usage

```python
my_shader = Shader.load(language=Shader.GLSL, vertex="shader.vert", fragment="shader.frag", geometry="shader.geom")
```

Shader parts are optional and if missing uses default vertex and fragment shaders.

Uses similar logic than loading textures. Currently only application asset path is defined.
