### PR TITLE
Dynamic Aspect Ratio Request

### DIFF
--- a/ursina/camera.py
+++ b/ursina/camera.py
@@ -35,7 +35,7 @@ class Camera(Entity):
         self.perspective_lens = PerspectiveLens()
         self.perspective_lens = base.camLens # use panda3d's default for automatic aspect ratio on window resize
         self.lens = self.perspective_lens
-        self.perspective_lens.set_aspect_ratio(16/9)
+        self.perspective_lens.set_aspect_ratio(window.screen_resolution[0] / window.screen_resolution[1])
         self.perspective_lens_node = LensNode('perspective_lens_node', self.perspective_lens)
         self.lens_node = self.perspective_lens_node
 


### PR DESCRIPTION
Petter,

You might recall that Camera-class uses hardcoded aspect ratio of 16/9 (ratio of 1.8). This stretches the world on wider monitors.

I propose using dynamic aspect ratio employng data that Ursina's Windows-class already contains. Namely we go from:

   self.perspective_lens.set_aspect_ratio(16/9) 

to 

   self.perspective_lens.set_aspect_ratio(window.screen_resolution[0] / window.screen_resolution[1])

I tested it on my 2.4 ratio external monitor and it works.

This pull request contains only this change. 

Please kindly consider if it would be convenient for you to adopt this change.

Respectfully,

Alex