### PR TITLE
fix bug with destroying buttons causing crash

### DIFF
--- a/ursina/mouse.py
+++ b/ursina/mouse.py
@@ -290,16 +290,19 @@ class Mouse():
 
     def unhover_everything_not_hit(self):
         for e in scene.entities:
-            if e == self.hovered_entity:
-                continue
+            try:
+                if e == self.hovered_entity:
+                    continue
 
-            if e.hovered:
-                e.hovered = False
-                if hasattr(e, 'on_mouse_exit'):
-                    e.on_mouse_exit()
-                for s in e.scripts:
-                    if hasattr(s, 'on_mouse_exit'):
-                        s.on_mouse_exit()
+                if e.hovered:
+                    e.hovered = False
+                    if hasattr(e, 'on_mouse_exit'):
+                        e.on_mouse_exit()
+                    for s in e.scripts:
+                        if hasattr(s, 'on_mouse_exit'):
+                            s.on_mouse_exit()
+            except:
+                pass
 
 
 
@@ -318,3 +321,4 @@ if __name__ == '__main__':
 
 
     app.run()
+


### PR DESCRIPTION
very occasional crash where unhover_everything_not_hit(self) calls e.hovered on an entity that has already been destroyed (might be related to threading issues)
just added try to ignore those cases.