### PR TITLE
Fix bug with loading greyscale heightmap terrain

### DIFF
--- a/ursina/models/procedural/terrain.py
+++ b/ursina/models/procedural/terrain.py
@@ -15,7 +15,7 @@ class Terrain(Mesh):
 
         self.skip = skip    # should be power of two.
         self.width, self.depth = self.heightmap.width//skip, self.heightmap.height//skip
-        img = Image.open(self.heightmap.path)
+        img = Image.open(self.heightmap.path).convert('RGB')
         if self.skip > 1:
             img = img.resize([self.width, self.depth], Image.ANTIALIAS)
 


### PR DESCRIPTION
some heightmaps when loaded don't have [R,G,B] for each pixel and just have a single value, which returns an error with getting j[0] from self.height_values = [[j[0]/255 for j in i] for i in self.height_values]

just modified single line to convert all images to that rgb form. Thanks