### PR TITLE
Better Trail Renderer

### DIFF
--- a/trail_renderer.py
+++ b/trail_renderer.py
@@ -1,0 +1,44 @@
+from ursina import *
+
+class TrailRenderer(Entity):
+    def __init__(self, color1, color2, target=None, length=5, **kwargs):
+        super().__init__()
+        self.target = target
+        self.model = Mesh(
+            vertices=[(target.world_position) for i in range(length)],
+            colors=[lerp(color1, color2, i/length) for i in range(10)],
+            mode='line',
+            thickness=5,
+            static=False
+        )
+        if not target:
+            target=self
+
+        self._t = 0
+        self.update_step = .01
+
+        for key, value in kwargs.items():
+             setattr(self, key ,value)
+
+
+    def update(self):
+        self._t += time.dt
+        if self._t >= self.update_step:
+            self._t = 0
+            self.model.vertices.pop(0)
+            self.model.vertices.append(self.target.world_position)
+            self.model.generate()
+        if all(elem == self.model.vertices[0] for elem in self.model.vertices):
+          destroy(self)
+
+
+if __name__ == '__main__':
+    app = Ursina()
+    mouse.visible = False
+    player = Entity(model='cube', scale=.1, color=color.orange)
+    trail_renderer = TrailRenderer(target=player)
+
+    def update():
+        player.position = mouse.position * 10
+
+    app.run()

--- a/trail_renderer.py
+++ b/trail_renderer.py
@@ -1,7 +1,7 @@
 from ursina import *
 
 class TrailRenderer(Entity):
-    def __init__(self, color1, color2, target=None, length=5, **kwargs):
+    def __init__(self, color1, color2, target=None, length=5, destroy_on_stop=False, **kwargs):
         super().__init__()
         self.target = target
         self.model = Mesh(
@@ -28,7 +28,7 @@ class TrailRenderer(Entity):
             self.model.vertices.pop(0)
             self.model.vertices.append(self.target.world_position)
             self.model.generate()
-        if all(elem == self.model.vertices[0] for elem in self.model.vertices):
+        if all(elem == self.model.vertices[0] for elem in self.model.vertices) and destroy_on_stop:
           destroy(self)
 
 

--- a/trail_renderer.py
+++ b/trail_renderer.py
@@ -1,14 +1,14 @@
 from ursina import *
 
 class TrailRenderer(Entity):
-    def __init__(self, color1, color2, target=None, length=5, destroy_on_stop=False, **kwargs):
+    def __init__(self, color1, color2, thickness=5, target=None, length=5, destroy_on_stop=False, **kwargs):
         super().__init__()
         self.target = target
         self.model = Mesh(
             vertices=[(target.world_position) for i in range(length)],
             colors=[lerp(color1, color2, i/length) for i in range(10)],
             mode='line',
-            thickness=5,
+            thickness=thickness,
             static=False
         )
         if not target:


### PR DESCRIPTION
Does what title says.
-Sets its initial vertexes to it's assigned target so there is not a line to 0,0,0 every time you make a TrailRenderer instance.
-Destroys the entity when it's target stops moving and the trail becomes a dot, but only if the destroy_on_stop is enabled.
-Adds the for loop that lets you edit instance attributes.
-Added several variables for ease of making instances without redefining the whole mesh.
-Changed the colors' lerp to be i/length, making a much more smooth transition between the colors.