### PR TITLE
Minecraft clone fix

### DIFF
--- a/samples/minecraft_clone.py
+++ b/samples/minecraft_clone.py
@@ -39,8 +39,8 @@ class Voxel(Button):
 
             if key == 'right mouse down':
                 destroy(self)
-	    if key == 'escape':			#added this for those who don't know that shift + Q closes ursina
-		exit()
+    	    if key == 'escape':			#added this for those who don't know that shift + Q closes ursina
+                exit()
 
 for z in range(8):
     for x in range(8):

--- a/samples/minecraft_clone.py
+++ b/samples/minecraft_clone.py
@@ -39,7 +39,8 @@ class Voxel(Button):
 
             if key == 'right mouse down':
                 destroy(self)
-
+	    if key == 'escape':			#added this for those who don't know that shift + Q closes ursina
+		exit()
 
 for z in range(8):
     for x in range(8):


### PR DESCRIPTION
Simply added the following code to make it easier to exit the program for those who don't know that shift + q makes the program exit.
`         if key == 'escape':
                   exit()
`

I apologize if this request seems a bit informal, this is one of my first times contributing code to a project on Github.