### PR TITLE
Event Handler Idea

### DIFF
--- a/ursina/__init__.py
+++ b/ursina/__init__.py
@@ -14,6 +14,7 @@ from ursina.main import Ursina
 from ursina.ursinamath import *
 from ursina.ursinastuff import *
 from ursina import input_handler
+from ursina import event_handler
 from ursina.input_handler import held_keys, Keys
 from ursina.string_utilities import *
 from ursina.mesh_importer import load_model, load_blender_scene

--- a/ursina/entity.py
+++ b/ursina/entity.py
@@ -29,6 +29,7 @@ from textwrap import dedent
 from panda3d.core import Shader as Panda3dShader
 from ursina.shader import Shader
 from ursina.string_utilities import print_info, print_warning
+from ursina import event_handler
 
 from ursina import color
 from ursina.color import Color
@@ -121,6 +122,15 @@ class Entity(NodePath):
                 self.on_disable()
             elif isinstance(self.on_disable, Sequence):
                 self.on_disable.start()
+
+        if hasattr(self, 'update') and callable(self.update):
+            event_handler.append_update_event(self)
+
+        if hasattr(self, 'input') and callable(self.input):
+            event_handler.append_input_event(self)
+            
+        if hasattr(self, 'keystroke') and callable(self.keystroke):
+            event_handler.append_keystroke_event(self)
 
 
     def _list_to_vec(self, value):
@@ -265,6 +275,14 @@ class Entity(NodePath):
             object.__setattr__(self, name, value)
             self.set_shader_input(name, value)
 
+        elif name == 'update':
+            event_handler.append_update_event(self, value != None)
+
+        elif name == 'input':
+            event_handler.append_input_event(self, value != None)
+
+        elif name == 'keystroke':
+            event_handler.append_keystroke_event(self, value != None)
 
         try:
             super().__setattr__(name, value)

--- a/ursina/event_handler.py
+++ b/ursina/event_handler.py
@@ -1,0 +1,22 @@
+
+event_update = []
+event_input = []
+event_key_input = []
+
+def _append_event(entity, append, event_list):
+    contained = entity in event_list
+
+    if not append and contained:
+        event_list.remove(entity)
+
+    elif append and not contained:
+        event_list.append(entity)
+
+def append_update_event(entity, append = True):
+    _append_event(entity, append, event_update)
+
+def append_input_event(entity, append = True):
+    _append_event(entity, append, event_input)
+
+def append_keystroke_event(entity, append = True):
+    _append_event(entity, append, event_key_input)

--- a/ursina/main.py
+++ b/ursina/main.py
@@ -5,6 +5,7 @@ from direct.task.Task import Task
 
 from ursina import application
 from ursina import input_handler
+from ursina import event_handler
 from ursina.window import instance as window
 from ursina.scene import instance as scene
 from ursina.camera import instance as camera
@@ -132,7 +133,7 @@ class Ursina(ShowBase):
         for seq in application.sequences:
             seq.update()
 
-        for entity in scene.entities:
+        for entity in event_handler.event_update:
             if entity.enabled == False or entity.ignore:
                 continue
 
@@ -191,7 +192,7 @@ class Ursina(ShowBase):
                 __main__.input(key)
 
 
-        for entity in scene.entities:
+        for entity in event_handler.event_input:
             if entity.enabled == False or entity.ignore or entity.ignore_input:
                 continue
             if application.paused and entity.ignore_paused == False:

--- a/ursina/ursinastuff.py
+++ b/ursina/ursinastuff.py
@@ -9,6 +9,7 @@ import time
 from pathlib import Path
 
 from ursina import application
+from ursina import event_handler
 from ursina.text import Text
 from ursina.window import instance as window
 from ursina.scene import instance as scene
@@ -73,6 +74,9 @@ def _destroy(entity, force_destroy=False):
     if entity in scene.entities:
         scene.entities.remove(entity)
 
+    event_handler.append_update_event(entity, False)
+    event_handler.append_input_event(entity, False)
+    event_handler.append_keystroke_event(entity, False)
 
     if hasattr(entity, 'scripts'):
         for s in entity.scripts:


### PR DESCRIPTION
During update() and input(), all entities in the scene are being checked even though they might never have that function.  Event handler has lists of all the entities that have specific functions like update or input that all need to be called at the same time.  When an Entity or class that inherits Entity is initialized with an update function, or the update function is set, the entity is added to the appropriate list.  If the Entity is destroyed or the function is set to None, the Entity is removed.  It's possible I've missed a situation where an entity is created that currently wouldn't add them to the list.

This is mostly a performance boost for scenes that have a thousand or more entities