### PR TITLE
is_playing set to True or False when paused or resumed?

### DIFF
--- a/ursina/prefabs/frame_animation_3d.py
+++ b/ursina/prefabs/frame_animation_3d.py
@@ -42,9 +42,11 @@ class FrameAnimation3d(Entity):
 
     def pause(self):
         self.sequence.pause()
+        self.is_playing = False
 
     def resume(self):
         self.sequence.resume()
+        self.is_playing = True
 
     def finish(self):
         self.sequence.finish()


### PR DESCRIPTION
Apologies if inappropriate -- I'm unfamiliar with animation, but was confused when is_playing remains True when paused.

Most likely my hacky use of the FrameAnimation3d() function to animate .obj files is just not how this is supposed to be used.