### PR TITLE
add windowless option to Ursina main class

### DIFF
--- a/ursina/main.py
+++ b/ursina/main.py
@@ -12,6 +12,7 @@ from ursina.mouse import instance as mouse
 from ursina.string_utilities import print_info
 from panda3d.core import KeyboardButton
 from panda3d.core import ConfigVariableBool
+from pandac.PandaModules import loadPrcFileData
 
 import __main__
 time.dt = 0
@@ -19,7 +20,12 @@ time.dt = 0
 
 class Ursina(ShowBase):
 
-    def __init__(self, **kwargs): # optional arguments: title, fullscreen, size, forced_aspect_ratio, position, vsync, borderless, show_ursina_splash, render_mode, development_mode, editor_ui_enabled.
+    def __init__(self, windowless=False, **kwargs): # optional arguments: title, fullscreen, size, forced_aspect_ratio, position, vsync, borderless, show_ursina_splash, render_mode, development_mode, editor_ui_enabled, windowless.
+
+        self.windowless = windowless
+        if self.windowless:
+            loadPrcFileData("", "window-type none")
+
         for name in ('size', 'vsync'):
             if name in kwargs and hasattr(window, name):
                 setattr(window, name, kwargs[name])
@@ -36,24 +42,26 @@ class Ursina(ShowBase):
         except:
             pass
 
-        window.late_init()
-        for name in ('title', 'fullscreen', 'position', 'show_ursina_splash', 'borderless', 'render_mode', 'forced_aspect_ratio'):
-            if name in kwargs and hasattr(window, name):
-                setattr(window, name, kwargs[name])
+        if not self.windowless:
+            window.late_init()
+            for name in ('title', 'fullscreen', 'position', 'show_ursina_splash', 'borderless', 'render_mode', 'forced_aspect_ratio'):
+                if name in kwargs and hasattr(window, name):
+                    setattr(window, name, kwargs[name])
 
-        # camera
-        camera._cam = base.camera
-        camera._cam.reparent_to(camera)
-        camera.render = base.render
-        camera.position = (0, 0, -20)
-        scene.camera = camera
-        camera.set_up()
+            # camera
+            camera._cam = base.camera
+            camera._cam.reparent_to(camera)
+            camera.render = base.render
+            camera.position = (0, 0, -20)
+            scene.camera = camera
+            camera.set_up()
 
-        # input
-        base.buttonThrowers[0].node().setButtonDownEvent('buttonDown')
-        base.buttonThrowers[0].node().setButtonUpEvent('buttonUp')
-        base.buttonThrowers[0].node().setButtonRepeatEvent('buttonHold')
-        base.buttonThrowers[0].node().setKeystrokeEvent('keystroke')
+            # input
+            base.buttonThrowers[0].node().setButtonDownEvent('buttonDown')
+            base.buttonThrowers[0].node().setButtonUpEvent('buttonUp')
+            base.buttonThrowers[0].node().setButtonRepeatEvent('buttonHold')
+            base.buttonThrowers[0].node().setKeystrokeEvent('keystroke')
+
         self._input_name_changes = {
             'mouse1' : 'left mouse down',
             'mouse1 up' : 'left mouse up',
@@ -129,7 +137,8 @@ class Ursina(ShowBase):
         # time between frames
         time.dt = globalClock.getDt() * application.time_scale
 
-        mouse.update()
+        if not self.windowless:
+            mouse.update()
 
         if hasattr(__main__, 'update') and __main__.update and not application.paused:
             __main__.update()


### PR DESCRIPTION
Added windowless option to Ursina main class.
Please let me know if you want any stylistic changes or discuss further issues.
Below is a test code that you can test both windowless=True and windowless=False mode.
It prints the time.dt to check the speed comparison as well as outputs of a raycast.hit to check it works.

    from ursina import *
    #app = Ursina(windowless=False)
    app = Ursina(windowless=True)
    
    e = Entity(model='plane', color=color.green, position=(0,0,0), scale=(50,1,50), rotation=(0,0,0), texture='ground', tileset_size=(.05,.05), collider='mesh')
    c = Entity(model='cube', color=color.red, rotation=(0,0,0), position=(0,0,0), scale=(10,5,10), collider='mesh', texture='cobble')
    
    G = 0
    def update():
        global G
        print(time.dt)
        G += 1
        c.position = (0,G%100,0)
        ray = raycast(c.position, c.down, ignore=(c,), distance=80)
        if ray.hit: print(1)
        else: print(0)
    
    app.run()