### PR TITLE
Setting Entity texture to None

### DIFF
--- a/ursina/entity.py
+++ b/ursina/entity.py
@@ -740,6 +740,7 @@ class Entity(NodePath):
         if value is None and self._texture:
             # print('remove texture')
             self.model.clearTexture()
+            self._texture = None
             return
 
         if value.__class__ is Texture:


### PR DESCRIPTION
Fixed bug where changing the model after changing a texture to None would cause it to reset to the last set texture.