### PR TITLE
Key input fix

### DIFF
--- a/ursina/main.py
+++ b/ursina/main.py
@@ -3,7 +3,6 @@ import platform
 
 from direct.showbase.ShowBase import ShowBase
 from direct.task.Task import Task
-from panda3d.core import KeyboardButton
 from panda3d.core import ConfigVariableBool
 
 from ursina import application

--- a/ursina/main.py
+++ b/ursina/main.py
@@ -236,13 +236,11 @@ class Ursina(ShowBase):
 
 
     def keystroke(self, key):
-        key = str(KeyboardButton.asciiKey(key))
-
-        if key == None:
+        key_code = ord(key)
+        if key_code < 32 or key_code >= 127 and key_code <= 160:
             return
-        if key == 'space':
-            key = ' '
-        if len(key) != 1:
+
+        if input_handler.held_keys['control'] or key != ' ' and key.isspace():
             return
 
         if not application.paused:


### PR DESCRIPTION
Removed the use of KeyboardButton.asciiKey() since it only checks a limited range of possible characters.  Keystroke now instead checks if the unicode value of the key is within a valid range.  If the value is one of the control characters specified by https://en.wikipedia.org/wiki/List_of_Unicode_characters , than it will exit the function.  I also included the non-breaking space as part of that range.