### PR TITLE
Made render queue attribute work for text.

### DIFF
--- a/ursina/entity.py
+++ b/ursina/entity.py
@@ -259,6 +259,13 @@ class Entity(NodePath):
         elif name == 'render_queue':
             if self.model:
                 self.model.setBin('fixed', value)
+            elif hasattr(self, 'text_nodes'):
+                #Updates the render queue of text nodes if they're present.
+                #This is because otherwise the render queue doesn't work properly for text.
+                for tn in self.text_nodes:
+                    tn.setBin('fixed', value)
+                for img in self.images:
+                    img.setBin('fixed', value)
 
         elif name == 'double_sided':
             self.setTwoSided(value)

--- a/ursina/text.py
+++ b/ursina/text.py
@@ -76,6 +76,9 @@ class Text(Entity):
 
             t += tn.node().text
 
+        #Calls the render queue setter to make sure the text nodes render properly
+        #This is so that the render queue will work when the text is changed
+        self.render_queue=self.render_queue
         return t
 
 


### PR DESCRIPTION
As it turns out, the render queue attribute didn't work for text entities at all due to how they used nodes. So I fixed it to update the text nodes properly.

_PS: I don't know why GitHub assumes I deleted all the files and rewrote them, I think it's because I uploaded them through the web client. The following is what I actually added._

**In Entity.py**
_Context: render queue attribute in setter_
```
            elif hasattr(self, 'text_nodes'):
                #Updates the render queue of text nodes if they're present.
                #This is because otherwise the render queue doesn't work properly for text.
                for tn in self.text_nodes:
                    tn.setBin('fixed', value)
                for img in self.images:
                    img.setBin('fixed', value)
```

**In Text.py**
_Context: Text property_
```
        #Calls the render queue setter to make sure the text nodes render properly
        #This is so that the render queue will work when the text is changed
        self.render_queue=self.render_queue
```