### PR TITLE
Headless

### DIFF
--- a/ursina/application.py
+++ b/ursina/application.py
@@ -18,6 +18,8 @@ dirs = [e.stem for e in asset_folder.parent.iterdir() if e.is_dir()]
 if 'src' in dirs and 'python' in dirs:
     development_mode = False
 
+window_type = 'onscreen'
+
 print_info = development_mode
 print_warnings = True
 raise_exception_on_missing_model = False

--- a/ursina/main.py
+++ b/ursina/main.py
@@ -29,7 +29,7 @@ def singleton(cls, **kwargs):
 @singleton
 class Ursina(ShowBase):
     def __init__(self, **kwargs): # optional arguments: title, fullscreen, size, forced_aspect_ratio, position, vsync, borderless, show_ursina_splash, render_mode, development_mode, editor_ui_enabled.
-        for name in ('size', 'vsync', 'forced_aspect_ratio'):
+        for name in ('title', 'size', 'vsync', 'forced_aspect_ratio'):
             if name in kwargs and hasattr(window, name):
                 setattr(window, name, kwargs[name])
 
@@ -54,7 +54,7 @@ class Ursina(ShowBase):
             pass
 
         window.late_init()
-        for name in ('title', 'fullscreen', 'position', 'show_ursina_splash', 'borderless', 'render_mode'):
+        for name in ('fullscreen', 'position', 'show_ursina_splash', 'borderless', 'render_mode'):
             if name in kwargs and hasattr(window, name):
                 setattr(window, name, kwargs[name])
 
@@ -205,12 +205,14 @@ class Ursina(ShowBase):
                 continue
 
             if hasattr(entity, 'input') and callable(entity.input):
-                entity.input(key)
+                if entity.input(key):
+                    break
 
             if hasattr(entity, 'scripts'):
                 for script in entity.scripts:
                     if script.enabled and hasattr(script, 'input') and callable(script.input):
-                        script.input(key)
+                        if script.input(key):
+                            break
 
 
         mouse.input(key)

--- a/ursina/main.py
+++ b/ursina/main.py
@@ -29,15 +29,23 @@ def singleton(cls, **kwargs):
 @singleton
 class Ursina(ShowBase):
     def __init__(self, **kwargs): # optional arguments: title, fullscreen, size, forced_aspect_ratio, position, vsync, borderless, show_ursina_splash, render_mode, development_mode, editor_ui_enabled.
-        for name in ('title', 'size', 'vsync', 'forced_aspect_ratio'):
+        for name in ('size', 'vsync', 'forced_aspect_ratio'):
             if name in kwargs and hasattr(window, name):
                 setattr(window, name, kwargs[name])
 
         if 'development_mode' in kwargs:
             application.development_mode = kwargs['development_mode']
 
+        window_type = 'onscreen'
+        p3d_window_type = None
+        if 'window_type' in kwargs:
+            window_type = kwargs['window_type']
+            if window_type != 'onscreen':
+                p3d_window_type = window_type
+        application.window_type = window_type
+
         application.base = self
-        super().__init__()
+        super().__init__(windowType=p3d_window_type)
 
         try:
             import gltf
@@ -46,23 +54,25 @@ class Ursina(ShowBase):
             pass
 
         window.late_init()
-        for name in ('fullscreen', 'position', 'show_ursina_splash', 'borderless', 'render_mode'):
+        for name in ('title', 'fullscreen', 'position', 'show_ursina_splash', 'borderless', 'render_mode'):
             if name in kwargs and hasattr(window, name):
                 setattr(window, name, kwargs[name])
 
         # camera
-        camera._cam = self.camera
-        camera._cam.reparent_to(camera)
-        camera.render = self.render
-        camera.position = (0, 0, -20)
-        scene.camera = camera
-        camera.set_up()
+        if window_type != 'none':
+            camera._cam = self.camera
+            camera._cam.reparent_to(camera)
+            camera.render = self.render
+            camera.position = (0, 0, -20)
+            scene.camera = camera
+            camera.set_up()
 
         # input
-        self.buttonThrowers[0].node().setButtonDownEvent('buttonDown')
-        self.buttonThrowers[0].node().setButtonUpEvent('buttonUp')
-        self.buttonThrowers[0].node().setButtonRepeatEvent('buttonHold')
-        self.buttonThrowers[0].node().setKeystrokeEvent('keystroke')
+        if window_type == 'onscreen':
+            self.buttonThrowers[0].node().setButtonDownEvent('buttonDown')
+            self.buttonThrowers[0].node().setButtonUpEvent('buttonUp')
+            self.buttonThrowers[0].node().setButtonRepeatEvent('buttonHold')
+            self.buttonThrowers[0].node().setKeystrokeEvent('keystroke')
         self._input_name_changes = {
             'mouse1' : 'left mouse down', 'mouse1 up' : 'left mouse up', 'mouse2' : 'middle mouse down', 'mouse2 up' : 'middle mouse up', 'mouse3' : 'right mouse down', 'mouse3 up' : 'right mouse up',
             'wheel_up' : 'scroll up', 'wheel_down' : 'scroll down',
@@ -106,7 +116,8 @@ class Ursina(ShowBase):
         except e as Exception:
             print(e)
 
-        window.make_editor_gui()
+        if window_type != 'none':
+            window.make_editor_gui()
         if 'editor_ui_enabled' in kwargs:
             window.editor_ui.enabled = kwargs['editor_ui_enabled']
 
@@ -194,14 +205,13 @@ class Ursina(ShowBase):
                 continue
 
             if hasattr(entity, 'input') and callable(entity.input):
-                if entity.input(key):
-                    break
+                entity.input(key)
 
             if hasattr(entity, 'scripts'):
                 for script in entity.scripts:
                     if script.enabled and hasattr(script, 'input') and callable(script.input):
-                        if script.input(key):
-                            break
+                        script.input(key)
+
 
         mouse.input(key)
 

--- a/ursina/mouse.py
+++ b/ursina/mouse.py
@@ -192,6 +192,9 @@ class Mouse():
 
 
     def update(self):
+        if application.window_type != 'onscreen':
+            return
+
         if not self.enabled or not self._mouse_watcher.has_mouse() or self._locked_mouse_last_frame:
             self.velocity = Vec3(0,0,0)
             self._locked_mouse_last_frame = False

--- a/ursina/window.py
+++ b/ursina/window.py
@@ -55,8 +55,11 @@ class Window(WindowProperties):
                 size = NSScreen.mainScreen().frame().size
                 self.screen_resolution = [size.width, size.height]
         except:
-            from screeninfo import get_monitors
-            self.screen_resolution = [get_monitors()[0].width, get_monitors()[0].height]
+            try:
+                from screeninfo import get_monitors
+                self.screen_resolution = [get_monitors()[0].width, get_monitors()[0].height]
+            except:
+                self.screen_resolution = [0, 0]
 
         self.fullscreen_size = Vec2(*self.screen_resolution)
         self.windowed_size = self.fullscreen_size / 1.25
@@ -71,7 +74,8 @@ class Window(WindowProperties):
 
 
     def late_init(self):
-        self.center_on_screen()
+        if application.window_type != 'none':
+            self.center_on_screen()
         if not application.development_mode:
             self.fullscreen = True
 
@@ -80,9 +84,10 @@ class Window(WindowProperties):
         self.render_mode = 'default'
         self.editor_ui = None
 
-        base.accept('aspectRatioChanged', self.update_aspect_ratio)
-        if self.always_on_top:
-            self.setZOrder(WindowProperties.Z_top)
+        if application.window_type != 'none':
+            base.accept('aspectRatioChanged', self.update_aspect_ratio)
+            if self.always_on_top:
+                self.setZOrder(WindowProperties.Z_top)
 
 
     @property
@@ -315,6 +320,9 @@ class Window(WindowProperties):
 
 
     def __setattr__(self, name, value):
+        if application.window_type == 'none':
+            return
+
         try:
             super().__setattr__(name, value)
         except:


### PR DESCRIPTION
Added a headless mode. The mode can be set via the window_type parameter passed to the Ursina class. The parameter options are "onscreen" (default), "offscreen", and "none". This change is mostly a bunch of if statements sprinkled around to avoid initialization of various things that can't exist without an on screen window, or any window at all. I also added a try-except statement to `window.py` to allow for devices with no screen at all (`screen_resolution` gets set to `[0, 0]` in that case).