### PR TITLE
Made gltf/glb files use the no_srgb flag set to True by default.

### DIFF
--- a/ursina/application.py
+++ b/ursina/application.py
@@ -21,6 +21,8 @@ if 'src' in dirs and 'python' in dirs:
 
 window_type = 'onscreen'
 
+gltf_no_srgb = True
+
 print_info = development_mode
 print_warnings = True
 raise_exception_on_missing_model = False

--- a/ursina/main.py
+++ b/ursina/main.py
@@ -50,6 +50,9 @@ class Ursina(ShowBase):
         except:
             pass
 
+        if 'gltf_no_srgb' in kwargs:
+            application.gltf_no_srgb = kwargs['gltf_no_srgb']
+
         window.late_init()
         for name in ('fullscreen', 'position', 'show_ursina_splash', 'borderless', 'render_mode'):
             if name in kwargs and hasattr(window, name):

--- a/ursina/mesh_importer.py
+++ b/ursina/mesh_importer.py
@@ -10,11 +10,13 @@ from panda3d.core import CullFaceAttrib
 from time import perf_counter
 from ursina.string_utilities import print_info, print_warning
 from ursina import color
+import panda3d.core as p3d
+import gltf
 
 imported_meshes = dict()
 blender_scenes = dict()
 
-def load_model(name, path=application.asset_folder, file_types=('.bam', '.ursinamesh', '.obj', '.glb', '.gltf', '.blend'), use_deepcopy=False):
+def load_model(name, path=application.asset_folder, file_types=('.bam', '.ursinamesh', '.obj', '.glb', '.gltf', '.blend'), use_deepcopy=False, gltf_no_srgb=None):
     if not isinstance(name, str):
         raise TypeError(f"Argument save must be of type str, not {type(str)}")
 
@@ -43,6 +45,16 @@ def load_model(name, path=application.asset_folder, file_types=('.bam', '.ursina
             if filetype == '.bam':
                 print_info('loading bam')
                 return loader.loadModel(filename)  # type: ignore
+
+            if filetype == '.gltf' or filetype == '.glb':
+                gltf_settings = gltf.GltfSettings()
+                if gltf_no_srgb is None:
+                    gltf_settings.no_srgb = application.gltf_no_srgb
+                else:
+                    gltf_settings.no_srgb = gltf_no_srgb
+                model_root = gltf.load_model(str(filename), gltf_settings=gltf_settings)
+                model_node_path = p3d.NodePath(model_root)
+                return model_node_path
 
             if filetype == '.ursinamesh':
                 try:


### PR DESCRIPTION
Added and option for it in load_model, globally in application, and as a flag to the Ursina class. This is to fix the color issues experienced by many where the model is not as bright as expected or does not match what is seen in editors such as Blender. This was due to Panda3D's gltf module automatically converting from sRGB to linearized sRGB by default because it assumes that the user wants a linearized workflow, which is often what is desired when doing more complex shading. See how this works in the Panda3D docs: https://docs.panda3d.org/1.10/python/pipeline/converting-from-blender#why-do-my-colors-look-different-in-panda3d