### PR TITLE
Set movie texture to entity from load_texture

### DIFF
--- a/ursina/entity.py
+++ b/ursina/entity.py
@@ -797,6 +797,11 @@ class Entity(NodePath):
             self.model.clearTexture()
             self._texture = None
             return
+            
+        if value.__class__ is MovieTexture:
+            self._texture = value
+            self.model.setTexture(value, 1)
+            return
 
         if value.__class__ is Texture:
             texture = value


### PR DESCRIPTION
This update fix problem with set MovieTexture to entity after create object, it was possible to pass string with directory of movie and setter load file but you couldn't after this set to another video