### PR TITLE
Update terrain.py, error due to Pillow version 10.0.0.

### DIFF
--- a/ursina/models/procedural/terrain.py
+++ b/ursina/models/procedural/terrain.py
@@ -17,7 +17,7 @@ def texture_to_height_values(heightmap, skip=1):
     width, depth = heightmap.width//skip, heightmap.height//skip
     img = Image.open(heightmap.path).convert('L')
     if skip > 1:
-        img = img.resize([width, depth], Image.ANTIALIAS)
+        img = img.resize([width, depth], Image.LANCZOS)
 
     height_values = asarray(img)
     height_values = flip(height_values, axis=0)


### PR DESCRIPTION
The error is due to Pillow updated to 10.0.0. It has updated the name ```ANTIALIAS``` to ```LANCZOS```.
The error text says -
> AttributeError: module 'PIL.Image' has no attribute 'ANTIALIAS'

This PR fixes the issue.