### PR TITLE
Fix camera movement with optical mouse on MacOS

### DIFF
--- a/ursina/mouse.py
+++ b/ursina/mouse.py
@@ -103,7 +103,7 @@ class Mouse():
     def locked(self, value):
         self._locked = value
         if value:
-            window.set_mouse_mode(window.M_relative)
+            window.set_mouse_mode(window.M_confined)
         else:
             window.set_mouse_mode(window.M_absolute)
 


### PR DESCRIPTION
Tested on MacOS ventura (13.5) and openSUSE Tumbleweed (20230812)

Trackpad is still not working after this change.