### PR TITLE
Fixed entity python tag circular reference memory leak.

### DIFF
--- a/ursina/ursinastuff.py
+++ b/ursina/ursinastuff.py
@@ -152,6 +152,9 @@ def _destroy(entity, force_destroy=False):
     if hasattr(entity, '_on_click') and isinstance(entity._on_click, Sequence):
         entity._on_click.kill()
 
+    if entity.hasPythonTag("Entity"):
+        entity.clearPythonTag("Entity")
+
     entity.removeNode()
     #unload texture
     # if hasattr(entity, 'texture') and entity.texture != None:


### PR DESCRIPTION
A memory leak was being caused by Entity's reference to itself via the Panda3D Python tag system. This is fixed by clearing the tag on destruction allowing the garbage collector to collect the Entity.