### PR TITLE
Add smooth_normals option to load_blender_scene

### DIFF
--- a/ursina/mesh_importer.py
+++ b/ursina/mesh_importer.py
@@ -128,7 +128,7 @@ if application.development_mode:
             application.blender_paths['default'] = blender_exec
 
 
-def load_blender_scene(name, path=application.asset_folder, reload=False, skip_hidden=True, models_only=False, uvs=True, vertex_colors=True, normals=True, triangulate=True, decimals=4):
+def load_blender_scene(name, path=application.asset_folder, reload=False, skip_hidden=True, models_only=False, uvs=True, vertex_colors=True, normals=True, smooth_normals=False, triangulate=True, decimals=4):
     scenes_folder = Path(application.asset_folder / 'scenes')
     if not scenes_folder.exists():
         scenes_folder.mkdir()
@@ -156,6 +156,7 @@ def load_blender_scene(name, path=application.asset_folder, reload=False, skip_h
             '--uvs' if uvs else '',
             '--normals' if normals else '',
             '--vertex_colors' if vertex_colors else '',
+            '--smooth_normals' if smooth_normals else '',
             '--triangulate' if triangulate else '',
             f'--decimals={decimals}',
         ]

--- a/ursina/scripts/_blender_scene_to_ursina.py
+++ b/ursina/scripts/_blender_scene_to_ursina.py
@@ -105,7 +105,22 @@ for key, ob in unique_objects.items():
                 sharp_normals.append(averaged_normal)
 
         normals = sharp_normals
-
+        if '--smooth_normals' in sys.argv:
+            vertices=verts
+            bucket = list()
+            for i, v in enumerate(vertices):
+                if i in bucket:
+                    continue
+    
+                overlapping_verts_indices = list()
+                for j, w in enumerate(vertices):
+                    if w == v:
+                        overlapping_verts_indices.append(j)
+                        bucket.append(j)
+    
+                average_normal = sum(normals[e] for e in overlapping_verts_indices) / 3
+                for index in overlapping_verts_indices:
+                    normals[index] = average_normal
 
     if '--uvs' in sys.argv:
         uv_layer = mesh.uv_layers.active

--- a/ursina/scripts/_blender_scene_to_ursina.py
+++ b/ursina/scripts/_blender_scene_to_ursina.py
@@ -1,6 +1,7 @@
 import bpy
 import os
 import sys
+import numpy
 from pathlib import Path
 from math import degrees
 import bmesh
@@ -108,6 +109,7 @@ for key, ob in unique_objects.items():
         if '--smooth_normals' in sys.argv:
             vertices=verts
             bucket = list()
+            _normals = numpy.array(normals)
             for i, v in enumerate(vertices):
                 if i in bucket:
                     continue
@@ -117,10 +119,12 @@ for key, ob in unique_objects.items():
                     if w == v:
                         overlapping_verts_indices.append(j)
                         bucket.append(j)
-    
-                average_normal = sum(normals[e] for e in overlapping_verts_indices) / 3
+
+                average_normal = sum(_normals[e] for e in overlapping_verts_indices) / 3
                 for index in overlapping_verts_indices:
-                    normals[index] = average_normal
+                    _normals[index] = average_normal
+            normals = list(_normals)
+        normals = numpy.array(normals)
 
     if '--uvs' in sys.argv:
         uv_layer = mesh.uv_layers.active
@@ -129,11 +133,12 @@ for key, ob in unique_objects.items():
 
 
 
+    normals_string = numpy.array2string(normals, separator=',').replace('\n', '')
     code += f'''
 '{mesh.name}' : Mesh(
     vertices={str(verts).replace(' ', '')},
     triangles={polygons},
-    normals={str(normals).replace(' ', '')},
+    normals={normals_string.replace(' ', '')},
     colors={str(vertex_colors).replace(' ', '')},
     uvs={str(uvs).replace(' ', '')},
 ),


### PR DESCRIPTION
This'll run generate_normals() and when generating normals in _blender_scene_to_ursina.py if smooth_normals == True, If it isn't true, then the original algorithm will be used, That's the default behavior in order to not break old code.