### PR TITLE
Faster Mesh

### DIFF
--- a/ursina/mesh.py
+++ b/ursina/mesh.py
@@ -343,7 +343,7 @@ class Mesh(p3d.NodePath):
         if not name and hasattr(self, 'path'):
             name = self.path.stem
             if '.' not in name:
-                name += ".ursinamesh"
+                name += '.ursinamesh'
 
         if name.endswith('ursinamesh'):
             with open(folder / name, 'w') as f:
@@ -354,7 +354,7 @@ class Mesh(p3d.NodePath):
             import os
             name = str(os.path.splitext(name)[0])
             ursinamesh_to_obj(self, name, folder, flip_faces)
-        elif name.endswidth('.dae'):
+        elif name.endswith('.dae'):
             from ursina.mesh_exporter import ursinamesh_to_dae
             import os
             name = str(os.path.splitext(name)[0])

--- a/ursina/mesh.py
+++ b/ursina/mesh.py
@@ -212,45 +212,35 @@ class Mesh(p3d.NodePath):
             geom.addPrimitive(prim)
         else:
             if not isinstance(self.triangles[0], numbers.Real):
-                if len(self.triangles[0]) == 2:
-                    for line_segment in self.triangles:
-                        prim = Mesh._modes[self.mode](static_mode)
-                        prim.set_index_type(p3d.GeomEnums.NT_uint32)
-
-                        parray = prim.modify_vertices()
-
-                        parray.unclean_set_num_rows(len(line_segment))
-                        self._set_array_data(parray, line_segment, 'I')
-
-                        prim.close_primitive()
-                        geom.addPrimitive(prim)
-                if len(self.triangles[0]) == 3:
-                    prim = Mesh._modes[self.mode](static_mode)
+                line_segments = []
+                triangles = []
+                for tup in self.triangles:
+                    if len(tup) == 2:
+                        line_segments.append(tup)
+                    elif len(tup) == 3:
+                        triangles.extend(tup)
+                    elif len(tup) == 4:
+                        triangles.extend((tup[0], tup[1], tup[2],
+                                          tup[2], tup[3], tup[0]))
+                for line_segment in line_segments:
+                    prim = Mesh._modes['line'](static_mode)
                     prim.set_index_type(p3d.GeomEnums.NT_uint32)
 
                     parray = prim.modify_vertices()
 
-                    parray.unclean_set_num_rows(len(self.triangles) * 3)
-                    self._set_array_data(parray, self._ravel(self.triangles), 'I')
+                    parray.unclean_set_num_rows(len(line_segment))
+                    self._set_array_data(parray, line_segment, 'I')
 
                     prim.close_primitive()
                     geom.addPrimitive(prim)
-                elif len(self.triangles[0]) == 4:
+                if len(triangles) > 0:
                     prim = Mesh._modes[self.mode](static_mode)
                     prim.set_index_type(p3d.GeomEnums.NT_uint32)
 
                     parray = prim.modify_vertices()
 
-                    tris = bytearray()
-                    for quad in self.triangles:
-                        tris.extend(struct.pack(
-                            "6I",
-                            quad[0], quad[1], quad[2],
-                            quad[2], quad[3], quad[0]
-                        ))
-
-                    parray.unclean_set_num_rows(len(self.triangles) * 2)
-                    self._set_array_data(parray, tris, 'I')
+                    parray.unclean_set_num_rows(len(triangles))
+                    self._set_array_data(parray, triangles, 'I')
 
                     prim.close_primitive()
                     geom.addPrimitive(prim)

--- a/ursina/mesh.py
+++ b/ursina/mesh.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from enum import Enum
 from textwrap import dedent
 import struct
+import numbers
+import array
 
 from ursina import application
 from ursina import color

--- a/ursina/mesh.py
+++ b/ursina/mesh.py
@@ -1,18 +1,15 @@
-from panda3d.core import NodePath
-from panda3d.core import GeomVertexData, GeomVertexFormat, Geom, GeomVertexWriter, GeomNode
-from panda3d.core import GeomTriangles, GeomTristrips, GeomTrifans
-from panda3d.core import GeomLinestrips, GeomPoints
-from panda3d.core import TexGenAttrib, TextureStage
-from panda3d.core import LVector4f
-from ursina.vec3 import Vec3
+from pathlib import Path
+from enum import Enum
+from textwrap import dedent
+import struct
+
+from ursina import application
+from ursina import color
 from ursina.scripts.generate_normals import generate_normals
 from ursina.scripts.project_uvs import project_uvs
 from ursina.scripts.colorize import colorize
-from ursina import color
-from ursina import application
-from textwrap import dedent
-from enum import Enum
-from pathlib import Path
+
+import panda3d.core as p3d
 
 class MeshModes(Enum):
     triangle = 'triangle'
@@ -32,30 +29,27 @@ class MeshModes(Enum):
         return self.value == other
 
 
-
-
-class Mesh(NodePath):
-
+class Mesh(p3d.NodePath):
     _formats = {
-        (0,0,0) : GeomVertexFormat.getV3(),
-        (1,0,0) : GeomVertexFormat.getV3c4(),
-        (0,1,0) : GeomVertexFormat.getV3t2(),
-        (0,0,1) : GeomVertexFormat.getV3n3(),
-        (1,0,1) : GeomVertexFormat.getV3n3c4(),
-        (1,1,0) : GeomVertexFormat.getV3c4t2(),
-        (0,1,1) : GeomVertexFormat.getV3n3t2(),
-        (1,1,1) : GeomVertexFormat.getV3n3c4t2(),
-        }
+        (0,0,0) : p3d.GeomVertexFormat.getV3(),
+        (1,0,0) : p3d.GeomVertexFormat.getV3c4(),
+        (0,1,0) : p3d.GeomVertexFormat.getV3t2(),
+        (0,0,1) : p3d.GeomVertexFormat.getV3n3(),
+        (1,0,1) : p3d.GeomVertexFormat.getV3n3c4(),
+        (1,1,0) : p3d.GeomVertexFormat.getV3c4t2(),
+        (0,1,1) : p3d.GeomVertexFormat.getV3n3t2(),
+        (1,1,1) : p3d.GeomVertexFormat.getV3n3c4t2(),
+    }
 
     _modes = {
-        'triangle' : GeomTriangles,
-        'tristrip' : GeomTristrips,
-        'ngon' : GeomTrifans,
-        'line' : GeomLinestrips,
-        'point' : GeomPoints,
-        }
+        'triangle' : p3d.GeomTriangles,
+        'tristrip' : p3d.GeomTristrips,
+        'ngon' : p3d.GeomTrifans,
+        'line' : p3d.GeomLinestrips,
+        'point' : p3d.GeomPoints,
+    }
 
-    def __init__(self, vertices=None, triangles=None, colors=None, uvs=None, normals=None, static=True, mode='triangle', thickness=1, render_points_in_3d=True):
+    def __init__(self, vertices=None, triangles=None, colors=None, uvs=None, normals=None, static=True, mode='triangle', thickness=1, render_points_in_3d=True, vertex_buffer=None, vertex_buffer_length=None, vertex_buffer_format=None):
         super().__init__('mesh')
         self.vertices = vertices
         self.triangles = triangles
@@ -66,97 +60,156 @@ class Mesh(NodePath):
         self.mode = mode
         self.thickness = thickness
         self.render_points_in_3d = render_points_in_3d
+        self.vertex_buffer = vertex_buffer
+        self.vertex_buffer_length = vertex_buffer_length
+        self.vertex_buffer_format = vertex_buffer_format
 
         for var in (('vertices', vertices), ('triangles', triangles), ('colors', colors), ('uvs', uvs), ('normals', normals)):
             name, value = var
             if value is None:
                 setattr(self, name, [])
 
-        if self.vertices != []:
+        if self.vertices != [] or self.vertex_buffer is not None:
             self.generate()
 
+    def _ravel(self, data):
+        if not isinstance(data[0], numbers.Real):
+            d = []
+            for v in data:
+                d.extend(v)
+            return d
+        return data
 
-    def generate(self):  # call this after setting some of the variables to update it
+    def _set_array_data(self, array_handle, data, dtype_string='f'):
+        a = None
+        try:
+            a = memoryview(data).cast('B').cast(dtype_string)
+        except:
+            a = array.array(dtype_string, data)
+
+        vmem = memoryview(array_handle).cast('B').cast(dtype_string)
+        vmem[:] = a
+
+    def generate(self):
         if hasattr(self, 'geomNode'):
             self.geomNode.removeAllGeoms()
-
-        static_mode = Geom.UHStatic if self.static else Geom.UHDynamic
-        vertex_format = Mesh._formats[(bool(self.colors), bool(self.uvs), bool(self.normals))]
-        vdata = GeomVertexData('name', vertex_format, static_mode)
-        vdata.setNumRows(len(self.vertices)) # for speed
-        if not hasattr(self, 'geomNode'):
-            self.geomNode = GeomNode('mesh')
+        else:
+            self.geomNode = p3d.GeomNode('mesh_geom')
             self.attachNewNode(self.geomNode)
 
-        vertexwriter = GeomVertexWriter(vdata, 'vertex')
-        for v in self.vertices:
-            vertexwriter.addData3f(*v)
+        if len(self.vertices) == 0 and self.vertex_buffer is None:
+            return
 
-        if self.colors:
-            colorwriter = GeomVertexWriter(vdata, 'color')
-            for c in self.colors:
-                colorwriter.addData4f(LVector4f(*c))
+        static_mode = p3d.Geom.UHStatic if self.static else p3d.Geom.UHDynamic
 
-        if self.uvs:
-            uvwriter = GeomVertexWriter(vdata, 'texcoord')
-            for uv in self.uvs:
-                uvwriter.addData2f(uv[0], uv[1])
+        vertex_format = p3d.GeomVertexFormat()
 
-        if self.normals is not None:
-            normalwriter = GeomVertexWriter(vdata, 'normal')
-            for norm in self.normals:
-                normalwriter.addData3f(*norm)
+        if self.vertex_buffer is not None:
+            vertex_array_format = p3d.GeomVertexArrayFormat()
+            attributes = self.vertex_buffer_format.split(",")
+            for attribute in attributes:
+                attribute_type = attribute[0]
+                attribute_type_name = attribute[0]
+                if attribute_type == "p":
+                    attribute_type = p3d.Geom.C_point
+                    attribute_type_name = "vertex"
+                elif attribute_type == "c":
+                    attribute_type = p3d.Geom.C_color
+                    attribute_type_name = "color"
+                elif attribute_type == "t":
+                    attribute_type = p3d.Geom.C_texcoord
+                    attribute_type_name = "texcoord"
+                elif attribute_type == "n":
+                    attribute_type = p3d.Geom.C_normal
+                    attribute_type_name = "normal"
+                else:
+                    raise Exception("Invalid vertex buffer format attribute type: {}.".format(attribute_type))
+                attribute_count = int(attribute[1:-1])
+                attribute_dtype = attribute[-1]
+                if attribute_dtype == "f":
+                    attribute_dtype = p3d.Geom.NT_float32
+                elif attribute_dtype == "I":
+                    attribute_dtype = p3d.Geom.NT_uint32
+                else:
+                    raise Exception("Invalid vertex buffer format attribute data type: {}.".format(attribute_dtype))
+                vertex_array_format.addColumn(attribute_type_name, attribute_count, attribute_dtype, attribute_type)
+            vertex_format.addArray(vertex_array_format)
+        else:
+            vertex_format = p3d.GeomVertexFormat()
+            vertex_format.add_array(p3d.GeomVertexFormat.getV3().arrays[0])
+            if self.colors is not None and len(self.colors) > 0:
+                vertex_format.add_array(p3d.GeomVertexArrayFormat('color', 4, p3d.Geom.NT_float32, p3d.Geom.C_color))
+            if self.uvs is not None and len(self.uvs) > 0:
+                vertex_format.add_array(p3d.GeomVertexArrayFormat('texcoord', 2, p3d.Geom.NT_float32, p3d.Geom.C_texcoord))
+            if self.normals is not None and len(self.normals) > 0:
+                vertex_format.add_array(p3d.GeomVertexArrayFormat('normal', 3, p3d.Geom.NT_float32, p3d.Geom.C_normal))
 
+        vertex_format = p3d.GeomVertexFormat.register_format(vertex_format)
 
-        if self.mode != 'line' or not self._triangles:
-            self.indices = []
+        vdata = p3d.GeomVertexData('vertex_data', vertex_format, static_mode)
 
-            if self._triangles:
-                if isinstance(self._triangles[0], int):
-                    for t in self._triangles:
-                        self.indices.append(t)
-
-                elif len(self._triangles[0]) >= 3: # if tris are tuples like this: ((0,1,2), (1,2,3))
-                    for t in self._triangles:
-                        if len(t) == 3:
-                            self.indices.extend(t)
-
-                        elif len(t) == 4: # turn quad into tris
-                            self.indices.extend([t[i]for i in (0,1,2,2,3,0)])
-
+        if self.vertex_buffer is not None:
+            m = memoryview(self.vertex_buffer).cast('B')
+            vdata.unclean_set_num_rows(self.vertex_buffer_length)
+            array_handle = vdata.modify_array(0)
+            vmem = memoryview(array_handle).cast('B')
+            vmem[:] = m
+        else:
+            if isinstance(self.vertices[0], numbers.Real):
+                vdata.unclean_set_num_rows(len(self.vertices) // 3)
             else:
-                self.indices = [i for i in range(len(self.vertices))]
+                vdata.unclean_set_num_rows(len(self.vertices))
 
-            if not self.indices:
-                return
+            self._set_array_data(vdata.modify_array(0), self._ravel(self.vertices), 'f')
 
-            prim = Mesh._modes[self.mode](static_mode)
+            if self.colors is not None and len(self.colors) > 0:
+                self._set_array_data(vdata.modify_array(1), self._ravel(self.colors), 'f')
 
-            self.generated_vertices = [self.vertices[i] for i in self.indices]
-            for v in self.indices:
-                prim.addVertex(v)
+            if self.uvs is not None and len(self.uvs) > 0:
+                self._set_array_data(vdata.modify_array(2), self._ravel(self.uvs), 'f')
 
-            prim.close_primitive()
-            geom = Geom(vdata)
-            geom.addPrimitive(prim)
-            self.geomNode.addGeom(geom)
+            if self.normals is not None and len(self.normals) > 0:
+                self._set_array_data(vdata.modify_array(3), self._ravel(self.normals), 'f')
 
-        else:   # line with segments defined in triangles
-            for line in self._triangles:
-                prim = Mesh._modes[self.mode](static_mode)
-                for e in line:
-                    prim.addVertex(e)
-                prim.close_primitive()
-                geom = Geom(vdata)
-                geom.addPrimitive(prim)
-                self.geomNode.addGeom(geom)
+        prim = Mesh._modes[self.mode](static_mode)
+        prim.set_index_type(p3d.GeomEnums.NT_uint32)
+
+        parray = prim.modify_vertices()
+        parray.unclean_set_num_rows(len(self.triangles))
+
+        if not isinstance(self.triangles[0], numbers.Real) and len(self.triangles[0]) == 4:
+            tris = bytearray()
+            for quad in self.triangles:
+                tris.extend(struct.pack(
+                    "6I",
+                    quad[0], quad[1], quad[2],
+                    quad[2], quad[3], quad[0]
+                ))
+            self._set_array_data(parray, tris, 'I')
+        else:
+            self._set_array_data(parray, self._ravel(self.triangles), 'I')
+
+        prim.close_primitive()
+
+        geom = p3d.Geom(vdata)
+        geom.addPrimitive(prim)
+        self.geomNode.addGeom(geom)
 
         if self.mode == 'point':
-            self.setTexGen(TextureStage.getDefault(), TexGenAttrib.MPointSprite)
-            # self.set_render_mode_perspective(True)
+            self.setTexGen(p3d.TextureStage.getDefault(), p3d.TexGenAttrib.MPointSprite)
 
+    @property
+    def generated_vertices(self):
+        if not hasattr(self, "_generated_vertices"):
+            if self.triangles is not None and len(self.triangles) > 0:
+                return [self.vertices[i] for i in self.triangles]
+            else:
+                return [v for v in self.vertices]
+        return self._generated_vertices
 
-        # print('finished')
+    @generated_vertices.setter
+    def generated_vertices(self, value):
+        self._generated_vertices = value
 
     @property
     def recipe(self):
@@ -165,16 +218,21 @@ class Mesh(NodePath):
 
         return dedent(f'''
             Mesh(
-                vertices={[tuple(e) for e in self.vertices]},
-                triangles={self._triangles},
-                colors={[tuple(e) for e in self.colors]},
-                uvs={self.uvs},
-                normals={[tuple(e) for e in self.normals]},
+                vertices={list(self.vertices)},
+                triangles={list(self.triangles)},
+                colors={list(self.colors)},
+                uvs={list(self.uvs)},
+                normals={list(self.normals)},
                 static={self.static},
                 mode="{self.mode}",
-                thickness={self.thickness}
+                thickness={self.thickness},
+                render_points_in_3d={self.render_points_in_3d},
+                vertex_buffer={self.vertex_buffer},
+                vertex_buffer_length={self.vertex_buffer_length},
+                vertex_buffer_format="{self.vertex_buffer_format}"
             )
         ''')
+
     @recipe.setter
     def recipe(self, value):
         self._recipe = value
@@ -188,7 +246,6 @@ class Mesh(NodePath):
         self._render_points_in_3d = value
         self.set_render_mode_perspective(value)
 
-
     def __repr__(self):
         if not self.name == 'mesh':
             return self.name
@@ -199,26 +256,36 @@ class Mesh(NodePath):
         if hasattr(self, 'name'):
             return self.name
 
-
     def __add__(self, other):
+        if self.vertex_buffer is not None:
+            raise Exception("Can't add mesh with vertex buffer to another mesh (operation not supported).")
+
         self.vertices += other.vertices
         self.triangles += other.triangles
         if other.colors:
             self.colors += other.colors
         else:
             self.colors += (color.white, ) * len(other.vertices)
-
         self.normals += other.normals
         self.uvs += other.uvs
 
-
-
     def __deepcopy__(self, memo):
-        m = Mesh(self.vertices, self.triangles, self.colors, self.uvs, self.normals, self.static, self.mode, self.thickness)
+        m = Mesh(
+            vertices=self.vertices,
+            triangles=self.triangles,
+            colors=self.colors,
+            uvs=self.uvs,
+            normals=self.normals,
+            static=self.static,
+            mode=self.mode,
+            thickness=self.thickness,
+            render_points_in_3d=self.render_points_in_3d,
+            vertex_buffer=self.vertex_buffer,
+            vertex_buffer_length=self.vertex_buffer_length,
+            vertex_buffer_format=self.vertex_buffer_format
+        )
         m.name = self.name
         return m
-
-
 
     @property
     def thickness(self):
@@ -231,7 +298,10 @@ class Mesh(NodePath):
     @property
     def triangles(self):
         if self._triangles is None:
-            self._triangles = [(i, i+1, i+2) for i in range(0, len(self.vertices), 3)]
+            if self.mode == 'line':
+                self._triangles = [(i, i + 1) for i in range(0, len(self.vertices), 2)]
+            else:
+                self._triangles = [(i, i + 1, i + 2) for i in range(0, len(self.vertices), 3)]
 
         return self._triangles
 
@@ -239,26 +309,30 @@ class Mesh(NodePath):
     def triangles(self, value):
         self._triangles = value
 
-
-    def generate_normals(self, smooth=True):
+    def generate_normals(self, smooth=True, regenerate=True):
         self.normals = list(generate_normals(self.vertices, self.triangles, smooth))
-        self.generate()
+        if regenerate:
+            self.generate()
         return self.normals
-
 
     def colorize(self, left=color.white, right=color.blue, down=color.red, up=color.green, back=color.white, forward=color.white, smooth=True, world_space=True, strength=1):
         colorize(self, left, right, down, up, back, forward, smooth, world_space, strength)
 
-
     def project_uvs(self, aspect_ratio=1, direction='forward'):
         project_uvs(self, aspect_ratio)
 
-
     def clear(self, regenerate=True):
-        self.vertices, self.triangles, self.colors, self.uvs, self.normals = [], [], [], [], []
+        if self.vertex_buffer is not None:
+            self.vertex_buffer = None
+            self.vertex_buffer_length = None
+            self.vertex_buffer_format = None
+        self.vertices = []
+        self.triangles = []
+        self.colors = []
+        self.uvs = []
+        self.normals = []
         if regenerate:
             self.generate()
-
 
     def save(self, name='', folder:Path=application.compressed_models_folder, flip_faces=False):
         if not application.compressed_models_folder.exists():
@@ -267,33 +341,25 @@ class Mesh(NodePath):
         if not name and hasattr(self, 'path'):
             name = self.path.stem
             if '.' not in name:
-                name += '.ursinamesh'
+                name += ".ursinamesh"
 
         if name.endswith('ursinamesh'):
             with open(folder / name, 'w') as f:
-                # recipe = self.recipe.replace('LVector3f', '')
                 f.write(self.recipe)
             print('saved .ursinamesh to:', folder / name)
-
         elif name.endswith('.obj'):
             from ursina.mesh_exporter import ursinamesh_to_obj
             import os
-            # Remove the file extension, so we don't get 'name.obj.obj'
             name = str(os.path.splitext(name)[0])
             ursinamesh_to_obj(self, name, folder, flip_faces)
-
-        elif name.endswith('.dae'):
+        elif name.endswidth('.dae'):
             from ursina.mesh_exporter import ursinamesh_to_dae
             import os
-            # Remove the file extension, so we don't get 'name.dae.dae'
             name = str(os.path.splitext(name)[0])
             ursinamesh_to_dae(self, name, folder)
-
         elif name.endswith('.bam'):
             success = self.writeBamFile(folder / name)
             print('saved .bam to:', folder / name)
-
-
 
 
 if __name__ == '__main__':

--- a/ursina/mesh.py
+++ b/ursina/mesh.py
@@ -279,6 +279,10 @@ class Mesh(p3d.NodePath):
         if hasattr(self, '_recipe'):
             return self._recipe
 
+        vbuf_format = self.vertex_buffer_format
+        if vbuf_format is not None:
+            vbuf_format = f'"{vbuf_format}"'
+
         return dedent(f'''
             Mesh(
                 vertices={list(self.vertices)},
@@ -292,7 +296,7 @@ class Mesh(p3d.NodePath):
                 render_points_in_3d={self.render_points_in_3d},
                 vertex_buffer={self.vertex_buffer},
                 vertex_buffer_length={self.vertex_buffer_length},
-                vertex_buffer_format="{self.vertex_buffer_format}"
+                vertex_buffer_format={vbuf_format}
             )
         ''')
 
@@ -571,6 +575,9 @@ if __name__ == '__main__':
     clear_test = Entity(position=(12,-4), model=deepcopy(quad.model))
     clear_test.model.clear()
     Text(parent=clear_test, text='.clear() test', y=1, scale=5, origin=(0,-.5))
+
+    recipe_test = Entity(position=(12,-6), model=eval(quad.model.recipe))
+    Text(parent=recipe_test, text='.recipe test', y=1, scale=5, origin=(0,-.5))
 
     window.color = color.black
     EditorCamera()


### PR DESCRIPTION
I have rewritten the Mesh class to have faster generation.

In addition, the vertices, colors, uvs, normals, triangles can also be bytes-like objects now (e.g. array.array, numpy arrays, or bytearray).

Triangles can have mixed line segments, triangles, and quads via tuples of length 2, 3, and 4 respectively.

I have added a new vertex_buffer parameter to the init with the vertex_buffer_length parameter being the number of vertices in the vertex buffer, and vertex_buffer_format being a vertex format string for the vertex buffer. The vertex buffer format string's format is comma separated triplets of number, data type, attribute type. Example: `"3fp,4fc,3fn"`. The number at the start of each triplet is how many values. The letter following the number is the data type of those values. The current types supported are "f" for 32 bit floats, and "I" for unsigned 32 bit integers. The letters are intended to follow the same convention as found in Python's struct functions (https://docs.python.org/3/library/struct.html#format-characters). Following that first character, is another character that specifies the vertex attribute type. The current supported types are "p" for vertex position, "c" for vertex color, "t" for texture coordinate, and "n" for normal vector. The given sample has vertices with a position composed of 3 floats, a color composed of 4 floats, and a normal composed of 3 floats.
