### PR TITLE
Fast Mesh bug fixes.

### DIFF
--- a/ursina/mesh.py
+++ b/ursina/mesh.py
@@ -71,7 +71,7 @@ class Mesh(p3d.NodePath):
             if value is None:
                 setattr(self, name, [])
 
-        if self.vertices != [] or self.vertex_buffer is not None:
+        if (self.vertices is not None and len(self.vertices) > 0) or self.vertex_buffer is not None:
             self.generate()
 
     def _ravel(self, data):


### PR DESCRIPTION
Allowing bytes-like for vertices, and fixing generated_vertices to work with tuple triangles. Also merged with fixes on master for line case with uvs or normals.

Generated vertices are now cached, and cleared on a call to generate.