### PR TITLE
Mesh fix for no triangles given case.

### DIFF
--- a/ursina/mesh.py
+++ b/ursina/mesh.py
@@ -185,9 +185,9 @@ class Mesh(p3d.NodePath):
             prim.set_index_type(p3d.GeomEnums.NT_uint32)
 
             parray = prim.modify_vertices()
-            self.triangles = [i for i in range(len(self.vertices))]
-            parray.unclean_set_num_rows(len(self.triangles))
-            self._set_array_data(parray, self._ravel(self.triangles), 'I')
+            triangles = [i for i in range(len(self.vertices))]
+            parray.unclean_set_num_rows(len(triangles))
+            self._set_array_data(parray, self._ravel(triangles), 'I')
 
             prim.close_primitive()
             geom.addPrimitive(prim)


### PR DESCRIPTION
Made the triangles generated in the generate method for the no triangles given by user case a temporary passed to Panda3D and then discarded.