### PR TITLE
Fix a "walk up slope" check

### DIFF
--- a/ursina/prefabs/first_person_controller.py
+++ b/ursina/prefabs/first_person_controller.py
@@ -76,7 +76,7 @@ class FirstPersonController(Entity):
                     self.land()
                 self.grounded = True
                 # make sure it's not a wall and that the point is not too far up
-                if ray.world_normal.y > .7 and ray.world_point.y - self.world_y < .5: # walk up slope
+                if ray.world_normal.y < .7 and ray.world_point.y - self.world_y < .5: # walk up slope
                     self.y = ray.world_point[1]
                 return
             else:


### PR DESCRIPTION
ray.world_normal.y > .7 would prevent real slopes from being considered slopes because it would check if the normal was straight other than a curved slope.