### PR TITLE
Fast Mesh fix for no triangles given case and vertices are flat numbers.

### DIFF
--- a/ursina/mesh.py
+++ b/ursina/mesh.py
@@ -186,9 +186,12 @@ class Mesh(p3d.NodePath):
             prim.set_index_type(p3d.GeomEnums.NT_uint32)
 
             parray = prim.modify_vertices()
-            triangles = [i for i in range(len(self.vertices))]
-            parray.unclean_set_num_rows(len(triangles))
-            self._set_array_data(parray, self._ravel(triangles), 'I')
+            n = len(self.vertices)
+            if isinstance(self.vertices[0], numbers.Real):
+                n = n // 3
+            triangles = [i for i in range(n)]
+            parray.unclean_set_num_rows(n)
+            self._set_array_data(parray, triangles, 'I')
 
             prim.close_primitive()
             geom.addPrimitive(prim)


### PR DESCRIPTION
Fixed mesh no triangles given case where vertices are not tuples, etc, but flat real numbers. Now both flat array for vertices and tuples, Vec, etc, work.