### PR TITLE
Fix race condition

### DIFF
--- a/ursina/prefabs/first_person_controller.py
+++ b/ursina/prefabs/first_person_controller.py
@@ -3,6 +3,7 @@ from ursina import *
 
 class FirstPersonController(Entity):
     def __init__(self, **kwargs):
+        self.prepared = False
         self.cursor = Entity(parent=camera.ui, model='quad', color=color.pink, scale=.008, rotation_z=45)
         super().__init__()
         self.speed = 5
@@ -36,9 +37,13 @@ class FirstPersonController(Entity):
             ray = raycast(self.world_position+(0,self.height,0), self.down, traverse_target=self.traverse_target, ignore=self.ignore_list)
             if ray.hit:
                 self.y = ray.world_point.y
+        self.prepared = True
 
 
     def update(self):
+        if not self.prepared:
+            return
+            
         self.rotation_y += mouse.velocity[0] * self.mouse_sensitivity[1]
 
         self.camera_pivot.rotation_x -= mouse.velocity[1] * self.mouse_sensitivity[0]


### PR DESCRIPTION
There is a race condition before the variables are made where the update function runs before the rest of the code is initialized.
First, yes, here is proof of the crash.
![image](https://github.com/pokepetter/ursina/assets/69512353/5caf2855-6ceb-4c6f-aeff-cea6d591d051)

Second, CustomFPC is not the reason, this is the code for CustomFPC, it calls super().\_\_init\_\_() which runs FirstPersonController's \_\_init\_\_ function and the rest is handled by FirstPersonController.

```python
class customFPC(FirstPersonController):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
    def input(self, key):
        super().input(key)
        playerID = decodedGameToken[0]
        if playerID in gameState['PLAYERS'] and key == 'left mouse down':
            server.send(server.connections[0], b'FIRE\x00' + serverToken.encode('ascii'))
```

Last, if setting the self.enabled to False also works, its better to do that, I just couldn't replicate this race condition to test that.