### PR TITLE
Fixes MeshColliders for .glb and .bam imported meshes

### DIFF
--- a/ursina/collider.py
+++ b/ursina/collider.py
@@ -122,10 +122,10 @@ class MeshCollider(Collider):
 
             # ursina uses a left handed y-up coordinate system
             # but panda3d uses a right handed z-up coordinate system
-            vertl = list(map(lambda v : Vec3(v[0],-v[2],v[1]), verts))
+            verts = list(map(lambda v : Vec3(v[0],-v[2],v[1]), verts))
 
             for i in range(0, len(verts)-3, 3):
-                p = CollisionPolygon(vertl[i+2], vertl[i+1], vertl[i])
+                p = CollisionPolygon(verts[i+2], verts[i+1], verts[i])
                 self.collision_polygons.append(p)
 
         super().__init__(entity, self.collision_polygons)

--- a/ursina/collider.py
+++ b/ursina/collider.py
@@ -120,8 +120,12 @@ class MeshCollider(Collider):
                                 vertex_reader.setRow(vi)
                                 verts.append(vertex_reader.getData3())
 
+            # ursina uses a left handed y-up coordinate system
+            # but panda3d uses a right handed z-up coordinate system
+            vertl = list(map(lambda v : Vec3(v[0],-v[2],v[1]), verts))
+
             for i in range(0, len(verts)-3, 3):
-                p = CollisionPolygon(Vec3(verts[i+2]), Vec3(verts[i+1]), Vec3(verts[i]))
+                p = CollisionPolygon(vertl[i+2], vertl[i+1], vertl[i])
                 self.collision_polygons.append(p)
 
         super().__init__(entity, self.collision_polygons)

--- a/ursina/collider.py
+++ b/ursina/collider.py
@@ -122,7 +122,7 @@ class MeshCollider(Collider):
 
             # ursina uses a left handed y-up coordinate system
             # but panda3d uses a right handed z-up coordinate system
-            verts = list(map(lambda v : Vec3(v[0],-v[2],v[1]), verts))
+            verts = list(map(lambda v : Vec3(v[0],v[2],v[1]), verts))
 
             for i in range(0, len(verts)-3, 3):
                 p = CollisionPolygon(verts[i+2], verts[i+1], verts[i])


### PR DESCRIPTION
When importing .glb and .bam models and creating a MeshCollider from them, the resulting collider is rotated 90 degrees due to the difference between Ursina and Panda3D's coordinate systems.

I added an extra step in the generation of a MeshCollider from a NodePath to correct for this difference.