### PR TITLE
networking: Make invalid number of arguments message an fstring

### DIFF
--- a/ursina/networking.py
+++ b/ursina/networking.py
@@ -868,7 +868,7 @@ class RPCPeer:
         if proc_func is not None and proc_arg_types is not None and proc_arg_values is not None:
             if len(proc_arg_values) != len(proc_arg_types):
                 print("WARNING: Received invalid remote procedure call, disconnecting...")
-                print("Received an invalid number of arguments for procedure '{proc_name}'.")
+                print(f"Received an invalid number of arguments for procedure '{proc_name}'.")
                 connection.disconnect()
             else:
                 if self.peer.is_hosting():


### PR DESCRIPTION
This fixes an obvious typo in line 871 of networking.py; an error message was meant to be an f-string, but the "f" was excluded.