### PR TITLE
Fixed default cylinder offset and adjustment to physics example

### DIFF
--- a/ursina/models/procedural/cylinder.py
+++ b/ursina/models/procedural/cylinder.py
@@ -2,11 +2,17 @@ from ursina import *
 
 
 class Cylinder(Pipe):
-    def __init__(self, resolution=8, radius=.5, start=0, height=1, direction=(0,1,0), mode='triangle', **kwargs):
+    def __init__(self, resolution=8, radius=.5, height=1, direction=(0,1,0), mode='triangle', **kwargs):
         super().__init__(
             base_shape=Circle(resolution=resolution, radius=.5),
             origin=(0,0),
-            path=((0,start,0), Vec3(direction) * (height+start)),
+
+            path=(
+                (0,-(height/2),0), 
+                Vec3(direction) * 
+                (height/2)
+            ),
+
             thicknesses=((radius*2, radius*2),),
             mode=mode,
             **kwargs
@@ -15,7 +21,7 @@ class Cylinder(Pipe):
 
 if __name__ == '__main__':
     app = Ursina()
-    Entity(model=Cylinder(6, start=-.5), color=color.hsv(60,1,1,.3))
+    Entity(model=Cylinder(6), color=color.hsv(60,1,1,.3))
     origin = Entity(model='quad', color=color.orange, scale=(5, .05))
     ed = EditorCamera(rotation_speed = 200, panning_speed=200)
     app.run()

--- a/ursina/physics.py
+++ b/ursina/physics.py
@@ -294,7 +294,7 @@ if __name__ == '__main__':
     capsule = Entity(model=Capsule(height=2, radius=.5), texture='brick', y=17)
     RigidBody(shape=CapsuleShape(height=2, radius=.5), entity=capsule, mass=3)
 
-    cylinder = Entity(model=Cylinder(height=2, radius=.5, start=-1), texture='brick', y=10)
+    cylinder = Entity(model=Cylinder(height=2, radius=.5), texture='brick', y=10)
     RigidBody(shape=CylinderShape(height=2, radius=.5), entity=cylinder, mass=3)
 
     cone = Entity(model=Cone(8, height=2, radius=.5), texture='brick', y=15)


### PR DESCRIPTION
I removed the start argument in the procedural cylinder which causes a vertical offset by default. The start argument just seems a bit odd considering the way the other procedural models work. It's not a big deal though, just a proposal.