### PR TITLE
Added a post_update global function and a post_update method for Entity.

### DIFF
--- a/ursina/entity.py
+++ b/ursina/entity.py
@@ -64,6 +64,8 @@ class Entity(NodePath, metaclass=PostInitCaller):
         self.add_to_scene_entities = add_to_scene_entities # set to False to be ignored by the engine, but still get rendered.
         if add_to_scene_entities:
             scene.entities.append(self)
+            if hasattr(self, 'post_update') and callable(self.post_update):
+                scene.post_update_entities.append(self)
 
         self._shader_inputs = {}
         if Entity.default_shader:

--- a/ursina/main.py
+++ b/ursina/main.py
@@ -192,6 +192,25 @@ class Ursina(ShowBase):
                 for key, value in e.shader.continuous_input.items():
                     e.set_shader_input(key, value())
 
+        if hasattr(__main__, 'post_update') and __main__.post_update and not application.paused:
+            __main__.post_update()
+
+        for e in scene.post_update_entities:
+            if not e.enabled or e.ignore:
+                continue
+            if application.paused and e.ignore_paused is False:
+                continue
+            if e.has_disabled_ancestor():
+                continue
+
+            if hasattr(e, 'post_update') and callable(e.post_update):
+                e.post_update()
+
+            if hasattr(e, 'scripts'):
+                for script in e.scripts:
+                    if script.enabled and hasattr(script, 'post_update') and callable(script.post_update):
+                        script.post_update()
+
         return Task.cont
 
 

--- a/ursina/scene.py
+++ b/ursina/scene.py
@@ -7,6 +7,7 @@ class Scene(NodePath):
     def __init__(self):
         super().__init__('scene')
         self.entities = []
+        self.post_update_entities = []
         self.collidables = set()
         self._children = []
 
@@ -32,9 +33,11 @@ class Scene(NodePath):
             except Exception as e:
                 print('failed to destroy entity', e)
 
-
         self.entities = to_keep
-
+        self.post_update_entities = []
+        for e in self.entities:
+            if hasattr(e, 'post_update') and callable(e.post_update):
+                self.post_update_entities.append(e)
 
         application.sequences.clear()
 

--- a/ursina/ursinastuff.py
+++ b/ursina/ursinastuff.py
@@ -94,6 +94,9 @@ def _destroy(entity, force_destroy=False):
     if entity in scene.entities:
         scene.entities.remove(entity)
 
+    if entity in scene.post_update_entities:
+        scene.post_update_entities.remove(entity)
+
     if entity in scene.collidables:
         scene.collidables.remove(entity)
 


### PR DESCRIPTION
These `post_update` functions are run in a separate phase after the regular update. This is useful for when some logic needs the most up-to-date data that is modified by from `update`. For example if the EditorCamera changes the camera position and you need that most up to date transform for a shader. A `pre_update` could be added in the future.