### PR TITLE
Fixed DirectionalLight update_bounds not being set in look_at and shadows being set with a delay in init.

### DIFF
--- a/ursina/lights.py
+++ b/ursina/lights.py
@@ -30,10 +30,11 @@ class DirectionalLight(Light):
         render.setLight(node_path)
         self.shadow_map_resolution = Vec2(1024, 1024)
 
+        self._bounds_entity = scene
+
+        self.shadows = shadows
         for key, value in kwargs.items():
             setattr(self, key ,value)
-
-        invoke(setattr, self, 'shadows', shadows, delay=1/60)
 
 
     @property
@@ -53,6 +54,7 @@ class DirectionalLight(Light):
     def update_bounds(self, entity=scene):  # update the shadow area to fit the bounds of target entity, defaulted to scene.
         # don't include skydome when calculating shadow bounds
         [e.disable() for e in Sky.instances]
+
         bounds = entity.get_tight_bounds(self)
         if bounds is not None:
             bmin, bmax = bounds
@@ -62,6 +64,12 @@ class DirectionalLight(Light):
             lens.set_film_size(bmax.xy - bmin.xy)
 
         [e.enable() for e in Sky.instances]
+        
+        self._bounds_entity = entity
+
+    def look_at(self, target, axis='forward', up=None): # up defaults to self.up
+        super().look_at(target, axis=axis, up=up)
+        self.update_bounds(self._bounds_entity)
 
 
 class PointLight(Light):


### PR DESCRIPTION
This fixes some issues where calling update_bounds during initialization of a scene would not respect the user's choice of bounds entity due to the invoke delay settings shadows which sets the bounds to the scene. In addition, look_at needs to update the bounds as it changes the viewing direction of the shadow camera (changing the frustum bounds).