### PR TITLE
procedural terrain: change to allow numpy array to be passed as input to Terrain()

### DIFF
--- a/ursina/models/procedural/terrain.py
+++ b/ursina/models/procedural/terrain.py
@@ -32,7 +32,7 @@ class Terrain(Mesh):
         if heightmap:
             self.height_values = texture_to_height_values(heightmap, skip)
 
-        elif height_values:
+        elif height_values is not None:
             self.height_values = height_values
 
 


### PR DESCRIPTION
when passing a numpy array as `height_value` to Terrain(), it results in
```
 File "ursina_env25/lib/python3.12/site-packages/ursina/models/procedural/terrain.py", line 35, in __init__
    elif height_values:
         ^^^^^^^^^^^^^
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

```
This PR changes that line to
``` 
    elif height_values is not None:
```
so that also numpy arrays are accepted - convenient when the terrain is generated with numpy.