### PR TITLE
copy scene.entities to avoid simultaneous iterating and mutating.

### DIFF
--- a/ursina/main.py
+++ b/ursina/main.py
@@ -188,7 +188,7 @@ class Ursina(ShowBase):
         for seq in application.sequences:
             seq.update()
 
-        for e in scene.entities:
+        for e in list(scene.entities):
             if not e.enabled or e.ignore:
                 continue
             if application.paused and e.ignore_paused is False:


### PR DESCRIPTION
The simplest possible fix though I'm not sure how this might impact performance if there are many entities.

Fixes #783.