### PR TITLE
Terrain: fix calculation of normals. Fix #709

### DIFF
--- a/ursina/models/procedural/terrain.py
+++ b/ursina/models/procedural/terrain.py
@@ -54,6 +54,8 @@ class Terrain(Mesh):
         _height_values = [[j/255 for j in i] for i in self.height_values]
         w, h = self.width, self.depth
         centering_offset = Vec2(-.5, -.5)
+        dx = 1/(w-1)
+        dz = 1/(h-1)
 
         # create the plane
         i = 0
@@ -68,9 +70,9 @@ class Terrain(Mesh):
 
                 # normals
                 if x > 0 and z > 0 and x < w-1 and z < h-1:
-                    rl =  _height_values[x+1][z] - _height_values[x-1][z]
-                    fb =  _height_values[x][z+1] - _height_values[x][z-1]
-                    self.normals.append(Vec3(rl, 1, fb).normalized())
+                    rl =  (_height_values[x+1][z] - _height_values[x-1][z]) / (2*dx)
+                    fb =  (_height_values[x][z+1] - _height_values[x][z-1]) / (2*dz)
+                    self.normals.append(Vec3(-rl, 1, -fb).normalized())
                 else:
                     self.normals.append(Vec3(0,1,0))
 


### PR DESCRIPTION
When calculating the mesh normals in Terrain:generate(), `rl` and `fb` are now central difference approximations of the derivatives of the height field, i.e. divide height differences by `(2*dx)` and `(2*dz)`. Also correct the signs in the normal vector.

The expression now agrees with [Wikipedia](https://en.wikipedia.org/wiki/Normal_(geometry)#Normal_to_general_surfaces_in_3D_space) and [this SO answer](https://stackoverflow.com/questions/6656358/calculating-normals-in-a-triangle-mesh/21660173#21660173).

