### PR TITLE
Normalize rotation axis in Entity.look_in_direction

### DIFF
--- a/ursina/entity.py
+++ b/ursina/entity.py
@@ -1181,7 +1181,7 @@ class Entity(NodePath, metaclass=PostInitCaller):
             )
         else:
             # Step 2: Find the rotation needed to align current_forward to the target direction
-            rotation_axis = cross_product(current_forward, direction)
+            rotation_axis = normalize_vector(cross_product(current_forward, direction))
             rotation_angle = math.acos(max(min(dot_product(current_forward, direction), 1.0), -1.0))
 
             # Step 3: Create a quaternion for this rotation


### PR DESCRIPTION
This pull request fixes a bug introduced in 0b09faef6864f23cd2836fcd7a7dfabf8fcbfdb9, where the look_in_direction function does not work for arbitrary directions (though it does seem to work when looking at the cardinal directions). This rendered raycast pretty much unusable and affected a lot of other things.