### PR TITLE
Make render mode remeber shaders

### DIFF
--- a/ursina/entity.py
+++ b/ursina/entity.py
@@ -983,6 +983,23 @@ class Entity(NodePath, metaclass=PostInitCaller):
         self.setRenderModeWireframe(value)
 
 
+    def show_normals_getter(self):
+        return self._show_normals
+
+
+    def show_normals_setter(self, value):
+        self._show_normals = value
+
+        if value:
+            from ursina.shaders import normals_shader
+            self._original_shader = self.shader
+            self.shader = normals_shader
+            self.set_shader_input('transform_matrix', self.getNetTransform().getMat())
+
+        elif hasattr(self, "_original_shader") and self._original_shader:
+            self.shader = self._original_shader
+
+
     # def generate_sphere_map(self, size=512, name=f'sphere_map_{len(scene.entities)}'):
     #     from ursina import camera
     #     _name = 'textures/' + name + '.jpg'

--- a/ursina/entity.py
+++ b/ursina/entity.py
@@ -1000,6 +1000,22 @@ class Entity(NodePath, metaclass=PostInitCaller):
             self.shader = self._original_shader
 
 
+    def collider_visible_getter(self):
+        return self._show_collider
+
+
+    def collider_visible_setter(self, value):
+        if self.collider:
+            self.collider.visible = value
+
+        if value:
+            self._original_color = self.color
+            self.color = color.clear
+
+        elif hasattr(self, "_original_color") and self._original_color:
+            self.color = self._original_color
+
+
     # def generate_sphere_map(self, size=512, name=f'sphere_map_{len(scene.entities)}'):
     #     from ursina import camera
     #     _name = 'textures/' + name + '.jpg'

--- a/ursina/window.py
+++ b/ursina/window.py
@@ -340,7 +340,7 @@ class Window(WindowProperties):
                     e.collider.visible = False
 
         for e in [e for e in scene.entities if e.model and e.alpha]:
-            e.setShaderAuto()
+            e.show_normals = False
 
         if value == 'wireframe':
             base.wireframeOn()
@@ -354,10 +354,8 @@ class Window(WindowProperties):
                     e.collider.visible = True
 
         elif value == 'normals':
-            from ursina.shaders import normals_shader
             for e in [e for e in scene.entities if e.model and e.alpha]:
-                e.shader = normals_shader
-                e.set_shader_input('transform_matrix', e.getNetTransform().getMat())
+                e.show_normals = True
 
 
     def next_render_mode(self):

--- a/ursina/window.py
+++ b/ursina/window.py
@@ -333,11 +333,8 @@ class Window(WindowProperties):
         base.wireframeOff()
 
         # disable collision display mode
-        if hasattr(self, 'original_colors'):
-            for i, e in enumerate([e for e in scene.entities if hasattr(e, 'color')]):
-                e.color = self.original_colors[i]
-                if e.collider:
-                    e.collider.visible = False
+        for e in [e for e in scene.entities if e.model or e.collider]:
+            e.collider_visible = False
 
         for e in [e for e in scene.entities if e.model and e.alpha]:
             e.show_normals = False
@@ -346,12 +343,8 @@ class Window(WindowProperties):
             base.wireframeOn()
 
         elif value == 'colliders':
-            self.original_colors = [e.color for e in scene.entities if hasattr(e, 'color')]
-            for e in scene.entities:
-                e.color = color.clear
-                if e.collider:
-                    # e.visible = False
-                    e.collider.visible = True
+            for e in [e for e in scene.entities if e.model or e.collider]:
+                e.collider_visible = True
 
         elif value == 'normals':
             for e in [e for e in scene.entities if e.model and e.alpha]:


### PR DESCRIPTION
This PR makes the render mode remember the shaders of entities and prevents any changes to the order of entities to mess up colors