### PR TITLE
Added `__repr__` method to `HitInfo`

### DIFF
--- a/ursina/hit_info.py
+++ b/ursina/hit_info.py
@@ -16,5 +16,5 @@ class HitInfo:
         return self.hit
 
     def __repr__(self):
-        values_str = ', '.join(f'{slot}={getattr(self, slot)!r}' for slot in self.__slots__)
+        values_str = ', '.join(f'{slot}={repr(getattr(self, slot))}' for slot in self.__slots__)
         return f'{self.__class__.__name__}({values_str})'


### PR DESCRIPTION
Added `__repr__` method to `HitInfo` class for debugging. Uses the predefined `__slots__` to dynamically generate a repr string, similar to that of the `Entity` class.