### PR TITLE
Changed `Array2D` `from_string` constructor to be `classmethod`

### DIFF
--- a/ursina/array_tools.py
+++ b/ursina/array_tools.py
@@ -63,8 +63,8 @@ class Array2D(list):
             self.height = int(height)
             super().__init__([[self.default_value for _ in range(self.height)] for _ in range(self.width)])
 
-    @staticmethod
-    def from_string(string, convert_to_type=str, starts_lower_left=True, split_lines_on=','):
+    @classmethod
+    def from_string(cls, string, convert_to_type=str, starts_lower_left=True, split_lines_on=','):
             string = string.strip()
             if starts_lower_left:
                 if split_lines_on == '':     # example input: '010\n001\n000'
@@ -72,9 +72,9 @@ class Array2D(list):
                 else:                       # example input: '0,1,0\n0,0,1\n0,0,0'
                     data = [[convert_to_type(word.strip()) for word in line.split(split_lines_on) if word] for line in string.split('\n') if line]
                 data = [list(row) for row in zip(*data[::-1], strict=True)]  # rotate
-                return Array2D(data=data)
+                return cls(data=data)
             else:
-                return Array2D(data=[[word.strip() for word in line.split(split_lines_on) if word] for line in string.split('\n') if line])
+                return cls(data=[[word.strip() for word in line.split(split_lines_on) if word] for line in string.split('\n') if line])
 
     def to_string(self, separator=', ', always_separate=False):
         lines = []


### PR DESCRIPTION
Changed `Array2D` `from_string` constructor / factory method, which was previously a `staticmethod`, to be a `classmethod`.

This is inline with common semantics of constructor / factory methods being class methods. It also fixes previously broken usage of this method with inheritance and child classes.

Previously, this code:
```py
class Test(Array2D):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
    def test(self):
        print("test")

t = Test.from_string("0,1,0\n0,0,1\n0,0,0")
t.test()
```
Would error, as the `from_string` static method always returns an instance of the parent class, and `t` would be of type `Array2D` instead of the child `Test` class, hence the `test` method would not exist on it. With the use of a class method instead, `t = Test.from_string(...)` returns an instance of the child class (`Test`) correctly.