### PR TITLE
fix: add missing Ursina import in fxaa shader example

### DIFF
--- a/ursina/shaders/screenspace_shaders/fxaa.py
+++ b/ursina/shaders/screenspace_shaders/fxaa.py
@@ -98,6 +98,7 @@ default_input={
 
 
 if __name__ == '__main__':
+    from ursina import *
     app = Ursina()
     window.color=color.black
 


### PR DESCRIPTION
Adds the missing `from ursina import *` import in the `__main__` example of fxaa.py.

Without this import, running the file directly raises:
NameError: name 'Ursina' is not defined

This change ensures the example runs correctly when executed as a script.