### PR TITLE
Fix colliders not showing in render mode

### DIFF
--- a/ursina/collider.py
+++ b/ursina/collider.py
@@ -11,6 +11,7 @@ class Collider(NodePath):
 
         self.shape = shape
         self.node_path = entity.attachNewNode(self.collision_node)
+        self.visible = False
 
         if isinstance(shape, list | tuple):
             for e in shape:


### PR DESCRIPTION
Set `visible` to false in Collider __init__ because `Entity.show_collider` checks if the collider has the attribute visible which fails if the variable/property is uninitialized.