### PR TITLE
Fix bare except clauses in ursina/entity.py

### DIFF
--- a/ursina/entity.py
+++ b/ursina/entity.py
@@ -853,7 +853,7 @@ class Entity(NodePath, metaclass=PostInitCaller):
 
         try:
             super().set_shader_input(name, value)
-        except:
+        except Exception:
             raise Exception(f'Incorrect input to shader: {name} {value}')
 
     def shader_input_getter(self):
@@ -1323,7 +1323,7 @@ class Entity(NodePath, metaclass=PostInitCaller):
     def __str__(self):
         try:
             return self.name
-        except:
+        except AttributeError:
             return '*destroyed entity*'
 
     def get_changes(self, target_class=None): # returns a dict of all the changes


### PR DESCRIPTION
Replace 2 bare `except:` clauses with specific exception types in `ursina/entity.py`.

**`set_shader_input`** (line ~856): uses `except Exception:` — this wraps a failed Panda3D shader input call and re-raises a cleaner error. Bare `except:` would also catch `SystemExit`/`KeyboardInterrupt`.

**`__str__`** (line ~1326): uses `except AttributeError:` — this handles accessing `.name` on a destroyed entity whose internal state has been cleaned up. `AttributeError` is the only expected failure here.