### PR TITLE
Fix: Handle transform property in Button scale initialization (Fixes #838)

### DIFF
--- a/ursina/prefabs/button.py
+++ b/ursina/prefabs/button.py
@@ -21,7 +21,7 @@ class Button(Entity):
             disabled=False, shader=unlit_shader, **kwargs):
         super().__init__(parent=parent)
 
-        for key in ('scale', 'scale_x', 'scale_y', 'scale_z', 'world_scale', 'world_scale_x', 'world_scale_y', 'world_scale_z'):
+        for key in ('scale', 'scale_x', 'scale_y', 'scale_z', 'world_scale', 'world_scale_x', 'world_scale_y', 'world_scale_z', 'transform', 'world_transform'):
             if key in kwargs:   # set the scale before model for correct corners
                 setattr(self, key, kwargs[key])
 


### PR DESCRIPTION
Fixes #838

Previously, button text size was calculated incorrectly when the button's 
scale was set via the 'transform' or 'world_transform' properties, since 
these properties were not included in the early-initialization list.

This caused inconsistent text sizes, especially when the button was highlighted.

Changes:
- Added 'transform' and 'world_transform' to the list of scale-related 
properties that are set before model and text initialization
- Ensures text is properly sized regardless of how scale is specified"