### PR TITLE
Fix in_out_quart returning None for t >= 0.5

### DIFF
--- a/ursina/curve.py
+++ b/ursina/curve.py
@@ -64,7 +64,7 @@ def in_out_quart(t):
     if t < .5:
         return 8 * t * t * t * t
     else:
-        1 - 8 * t1 * t1 * t1 * t1
+        return 1 - 8 * t1 * t1 * t1 * t1
 
 
 def in_quint(t):


### PR DESCRIPTION
The `else` branch of `in_out_quart` computes the eased value but never returns it:

```python
def in_out_quart(t):
    t1 = t - 1
    if t < .5:
        return 8 * t * t * t * t
    else:
        1 - 8 * t1 * t1 * t1 * t1   # no return
```

so `in_out_quart(t)` returns `None` for every `t >= 0.5`:

```python
>>> from ursina import curve
>>> curve.in_out_quart(0.25)
0.03125
>>> curve.in_out_quart(0.5)
None          # expected 0.5
>>> curve.in_out_quart(0.75)
None          # expected 0.96875
```

Used as an animation curve this breaks mid-tween: `Entity.animate()` does `t = curve(t)` then `lerp(a, b, t)`, and once the eased time crosses 0.5, `a + (b - a) * None` raises `TypeError`. So `Entity().animate_y(5, duration=1, curve=curve.in_out_quart)` plays the first half and then throws.

The fix adds the missing `return`. The value was already correct (standard easeInOutQuart), so nothing else changes:

```python
        return 1 - 8 * t1 * t1 * t1 * t1
```

After the change `in_out_quart` returns `0.5` at `t=0.5` (continuous with the first branch) and `1.0` at `t=1.0`, and is monotonic across `[0, 1]`.

Every other `in_out_*` easing function in this file returns in both branches (`in_out_quad`, `in_out_cubic`, `in_out_quint`), and the JS source noted in the file header (`easeInOutQuart`) returns this value too, so this is just the one that dropped the keyword. `ruff` and the CI `flake8` selection pass (the change also removes what was an expression statement with no effect).
